### PR TITLE
Fix error messages

### DIFF
--- a/ExampleApp/ExampleViewController.swift
+++ b/ExampleApp/ExampleViewController.swift
@@ -84,17 +84,17 @@ class ExampleViewController: UIViewController, UITableViewDataSource, UITableVie
 
     private func manualAuthenticateAll() {
         TradeItLauncher.linkedBrokerManager.authenticateAll(onSecurityQuestion: { securityQuestion, answerSecurityQuestion, cancelQuestion in
-            self.alertManager.show(
-                securityQuestion: securityQuestion,
+            self.alertManager.showSecurityQuestion(
+                securityQuestion,
                 onViewController: self,
                 onAnswerSecurityQuestion: answerSecurityQuestion,
                 onCancelSecurityQuestion: cancelQuestion)
         }, onFinished: {
-            self.alertManager.showOn(
-                viewController: self,
-                withAlertTitle: "authenticateAll finished",
-                withAlertMessage: "\(TradeItLauncher.linkedBrokerManager.linkedBrokers.count) brokers authenticated.",
-                withAlertActionTitle: "OK")
+            self.alertManager.showAlert(
+                onViewController: self,
+                withTitle: "authenticateAll finished",
+                withMessage: "\(TradeItLauncher.linkedBrokerManager.linkedBrokers.count) brokers authenticated.",
+                withActionTitle: "OK")
         })
     }
 

--- a/TradeItIosEmsApi/TradeItSession.h
+++ b/TradeItIosEmsApi/TradeItSession.h
@@ -16,17 +16,17 @@
 /**
  *  Required property as the connector is used to make the requests to the EMS servers
  */
-@property TradeItConnector *connector;
+@property TradeItConnector * _Nullable connector;
 
 /**
  *  Once the session has been established the session token is stored here.
  */
-@property NSString *token;
+@property NSString * _Nullable token;
 
 /**
  *  Recommended way to init as you'll always need a connector
  */
-- (id)initWithConnector:(TradeItConnector *)connector;
+- (id _Nullable)initWithConnector:(TradeItConnector * _Nonnull)connector;
 
 /**
  *  This will establish a session give the user's token and will set the userToken on the session.
@@ -37,7 +37,7 @@
  *  - It's also possible to recieve a TradeItSecurityQuestionResult in which you'll need to issue an answerSecurityQuestion request before you'll recieve the session token
  *  - TradeItErrorResult also possible please see https://www.trade.it/api#ErrorHandling for descriptions of error codes
  */
-- (void)authenticate:(TradeItLinkedLogin *)linkedLogin withCompletionBlock:(void (^)(TradeItResult *))completionBlock;
+- (void)authenticate:(TradeItLinkedLogin * _Nullable)linkedLogin withCompletionBlock:(void (^ _Nonnull)(TradeItResult * _Nonnull))completionBlock;
 
 /**
  *  Use this method to answer the broker secuirty question after the ems server sent a TradeItSecurityQuestionResult
@@ -46,7 +46,7 @@
  *
  *  @return TradeItResult. Can either be TradeItStockOrEtfTradeReviewResult, TradeItSecurityQuestionResult or TradeItErrorResult. Caller needs to cast the result to the appropriate sub-class depending on the result status value. Note that TradeItSecurityQuestionResult will be returned again if the answer is incorrect.
  */
-- (void)answerSecurityQuestion:(NSString*)answer withCompletionBlock:(void (^)(TradeItResult *))completionBlock;
+- (void)answerSecurityQuestion:(NSString * _Nullable)answer withCompletionBlock:(void (^ _Nonnull)(TradeItResult * _Nonnull))completionBlock;
 
 /**
  *  Will close out the users current session and remove it from the TradeItSession instance.
@@ -58,6 +58,6 @@
  *
  *  @return TradeItResult. Success indicates session still alive, TradeItErrorResult most commonly indicates the session has already expired, all error messages still apply though https://www.trade.it/api#ErrorHandling
  */
-- (void)keepSessionAliveWithCompletionBlock:(void (^)(TradeItResult *))completionBlock;
+- (void)keepSessionAliveWithCompletionBlock:(void (^ _Nonnull)(TradeItResult * _Nonnull))completionBlock;
 
 @end

--- a/TradeItIosTicketSDK2/TradeItAccountManagementViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItAccountManagementViewController.swift
@@ -50,7 +50,7 @@ class TradeItAccountManagementViewController: TradeItViewController, TradeItAcco
         
         self.alertManager.showOn(viewController: self,
                                               withAlertTitle: "Unlink \(self.linkedBroker.linkedLogin.broker)",
-                                              withAlertMessage: "Are you sure you want to unlink your account and remove all the associated data ?",
+                                              withAlertMessage: "Are you sure you want to unlink your account and remove all the associated data?",
                                               withAlertActionTitle: "Unlink",
             onAlertActionTapped: { () -> Void in
                 

--- a/TradeItIosTicketSDK2/TradeItAccountManagementViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItAccountManagementViewController.swift
@@ -48,10 +48,11 @@ class TradeItAccountManagementViewController: TradeItViewController, TradeItAcco
     
     @IBAction func unlinkAccountWasTapped(sender: AnyObject) {
         
-        self.alertManager.showOn(viewController: self,
-                                              withAlertTitle: "Unlink \(self.linkedBroker.linkedLogin.broker)",
-                                              withAlertMessage: "Are you sure you want to unlink your account and remove all the associated data?",
-                                              withAlertActionTitle: "Unlink",
+        self.alertManager.showAlert(
+            onViewController: self,
+            withTitle: "Unlink \(self.linkedBroker.linkedLogin.broker)",
+            withMessage: "Are you sure you want to unlink your account and remove all the associated data?",
+            withActionTitle: "Unlink",
             onAlertActionTapped: { () -> Void in
                 
                 self.linkedBrokerManager.unlinkBroker(self.linkedBroker)
@@ -87,18 +88,17 @@ class TradeItAccountManagementViewController: TradeItViewController, TradeItAcco
                 })
             },
             onSecurityQuestion: { (securityQuestion: TradeItSecurityQuestionResult, answerSecurityQuestion: (String) -> Void, cancelSecurityQuestion: () -> Void) in
-                self.alertManager.show(
-                    securityQuestion: securityQuestion,
+                self.alertManager.promptUserToAnswerSecurityQuestion(
+                    securityQuestion,
                     onViewController: self,
                     onAnswerSecurityQuestion: answerSecurityQuestion,
                     onCancelSecurityQuestion: cancelSecurityQuestion
                 )
             },
-            onFailure: { (tradeItErrorResult: TradeItErrorResult) -> Void in
-                self.alertManager.show(
-                    tradeItErrorResult: tradeItErrorResult,
-                    onViewController: self,
+            onFailure: { error in
+                self.alertManager.showRelinkError(error,
                     withLinkedBroker: self.linkedBroker,
+                    onViewController: self,
                     onFinished : { () -> Void in
                         onRefreshComplete(withAccounts: self.linkedBroker.accounts)
                 })

--- a/TradeItIosTicketSDK2/TradeItAccountSelectionViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItAccountSelectionViewController.swift
@@ -30,15 +30,15 @@ class TradeItAccountSelectionViewController: TradeItViewController, TradeItAccou
         // TODO: Need to think about how not to have to wrap every linked broker action in a call to authenticate
         self.linkedBrokerManager.authenticateAll(
             onSecurityQuestion: { securityQuestion, onAnswerSecurityQuestion, onCancelSecurityQuestion in
-                self.alertManager.show(
-                    securityQuestion: securityQuestion,
+                self.alertManager.promptUserToAnswerSecurityQuestion(
+                    securityQuestion,
                     onViewController: self,
                     onAnswerSecurityQuestion: onAnswerSecurityQuestion,
                     onCancelSecurityQuestion: onCancelSecurityQuestion
                 )
             },
-            onFailure:  { tradeItErrorResult, linkedBroker in
-                self.alertManager.show(tradeItErrorResult: tradeItErrorResult, onViewController: self, withLinkedBroker: linkedBroker, onFinished: {
+            onFailure:  { error, linkedBroker in
+                self.alertManager.showRelinkError(error, withLinkedBroker: linkedBroker, onViewController: self, onFinished: {
                     // QUESTION: is this just going to re-run authentication for all linked brokers again if one failed?
                         onRefreshComplete(withLinkedBrokers: self.linkedBrokerManager.getAllEnabledLinkedBrokers())
                     }

--- a/TradeItIosTicketSDK2/TradeItErrorResult+ErrorCodeHelpers.swift
+++ b/TradeItIosTicketSDK2/TradeItErrorResult+ErrorCodeHelpers.swift
@@ -9,10 +9,11 @@ enum TradeItErrorCode: Int {
 }
 
 extension TradeItErrorResult {
-    convenience init(title: String, message: String, code: TradeItErrorCode) {
+    convenience init(title: String, message: String = "Unknown response sent from the server.", code: TradeItErrorCode = .SYSTEM_ERROR) {
         self.init()
         self.shortMessage = title
         self.longMessages = [message]
+        self.systemMessage = message
         self.code = code.rawValue
     }
 

--- a/TradeItIosTicketSDK2/TradeItErrorResult+ErrorCodeHelpers.swift
+++ b/TradeItIosTicketSDK2/TradeItErrorResult+ErrorCodeHelpers.swift
@@ -9,6 +9,13 @@ enum TradeItErrorCode: Int {
 }
 
 extension TradeItErrorResult {
+    convenience init(title: String, message: String, code: TradeItErrorCode) {
+        self.init()
+        self.shortMessage = title
+        self.longMessages = [message]
+        self.code = code.rawValue
+    }
+
     func errorCode() -> TradeItErrorCode? {
         if let code = self.code?.integerValue {
             return TradeItErrorCode(rawValue: code)

--- a/TradeItIosTicketSDK2/TradeItLinkedBroker.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBroker.swift
@@ -17,7 +17,7 @@ public class TradeItLinkedBroker: NSObject {
                                                             onCancelSecurityQuestion: () -> Void) -> Void,
                                        onFailure: (TradeItErrorResult) -> Void) -> Void {
         let authenticationResponseHandler = YCombinator { handler in
-            { (tradeItResult: TradeItResult!) in
+            { (tradeItResult: TradeItResult) in
                 switch tradeItResult {
                 case let authenticationResult as TradeItAuthenticationResult:
                     self.error = nil
@@ -32,7 +32,11 @@ public class TradeItLinkedBroker: NSObject {
                             self.session.answerSecurityQuestion(securityQuestionAnswer, withCompletionBlock: handler)
                         },
                         onCancelSecurityQuestion: {
-                            handler(TradeItErrorResult.tradeErrorWithSystemMessage("User canceled the security question."))
+                            handler(TradeItErrorResult(
+                                title: "Authentication failed",
+                                message: "The security question was canceled.",
+                                code: .BROKER_AUTHENTICATION_ERROR
+                            ))
                         }
                     )
                 case let error as TradeItErrorResult:

--- a/TradeItIosTicketSDK2/TradeItLinkedBroker.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBroker.swift
@@ -43,7 +43,10 @@ public class TradeItLinkedBroker: NSObject {
                     self.error = error
                     onFailure(error)
                 default:
-                    handler(TradeItErrorResult.tradeErrorWithSystemMessage("Unknown response sent from the server for authentication."))
+                    handler(TradeItErrorResult(
+                        title: "Authentication failed",
+                        code: .BROKER_AUTHENTICATION_ERROR
+                    ))
                 }
             }
         }

--- a/TradeItIosTicketSDK2/TradeItLinkedBrokerAccount.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBrokerAccount.swift
@@ -43,7 +43,7 @@ public class TradeItLinkedBrokerAccount: NSObject {
                 self.linkedBroker.error = errorResult
                 onFailure(errorResult)
             default:
-                onFailure(TradeItErrorResult.tradeErrorWithSystemMessage("Unknown error getting balances"))
+                onFailure(TradeItErrorResult(title: "Balances failed"))
             }
         }
     }
@@ -73,7 +73,7 @@ public class TradeItLinkedBrokerAccount: NSObject {
                 self.linkedBroker.error = errorResult
                 onFailure(errorResult)
             default:
-                onFailure(TradeItErrorResult.tradeErrorWithSystemMessage("Unknown error getting positions"))
+                onFailure(TradeItErrorResult(title: "Positions failed"))
             }
         }
     }

--- a/TradeItIosTicketSDK2/TradeItLinkedBrokerAccount.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBrokerAccount.swift
@@ -43,7 +43,7 @@ public class TradeItLinkedBrokerAccount: NSObject {
                 self.linkedBroker.error = errorResult
                 onFailure(errorResult)
             default:
-                onFailure(TradeItErrorResult(title: "Balances failed"))
+                onFailure(TradeItErrorResult(title: "Failed to retrieve account balances"))
             }
         }
     }
@@ -73,7 +73,7 @@ public class TradeItLinkedBrokerAccount: NSObject {
                 self.linkedBroker.error = errorResult
                 onFailure(errorResult)
             default:
-                onFailure(TradeItErrorResult(title: "Positions failed"))
+                onFailure(TradeItErrorResult(title: "Failed to retrieve account positions"))
             }
         }
     }

--- a/TradeItIosTicketSDK2/TradeItLinkedBrokerManager.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBrokerManager.swift
@@ -148,7 +148,8 @@ import PromiseKit
 
     func unlinkBroker(linkedBroker: TradeItLinkedBroker) {
         self.tradeItConnector.unlinkLogin(linkedBroker.linkedLogin)
-        let index = self.linkedBrokers.indexOf(linkedBroker)
-        self.linkedBrokers.removeAtIndex(index!)
+        if let index = self.linkedBrokers.indexOf(linkedBroker) {
+            self.linkedBrokers.removeAtIndex(index)
+        }
     }
 }

--- a/TradeItIosTicketSDK2/TradeItLinkedBrokerManager.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBrokerManager.swift
@@ -26,11 +26,12 @@ import PromiseKit
         let tradeItSession = tradeItSessionProvider.provide(connector: self.tradeItConnector)
         let linkedBroker = TradeItLinkedBroker(session: tradeItSession, linkedLogin: linkedLogin)
         
-        //we need to provide an error when we load from the keychain in order to the authenticate all method to handle this linkBroker
-        let errorResult = TradeItErrorResult()
-        errorResult.systemMessage = "This linked broker needs to authenticate"
-        errorResult.code = TradeItErrorCode.SESSION_ERROR.rawValue
-        linkedBroker.error = errorResult
+        // Mark the linked broker as errored so that it will be authenticated next time authenticateAll is called
+        linkedBroker.error = TradeItErrorResult(
+            title: "Linked Broker initialized from keychain",
+            message: "This linked broker needs to authenticate.",
+            code: .SESSION_ERROR
+        )
 
         return linkedBroker
     }
@@ -92,12 +93,13 @@ import PromiseKit
                     let linkedBroker = self.loadLinkedBrokerFromLinkedLogin(linkedLogin)
                     onSuccess(linkedBroker: linkedBroker)
                 } else {
-                    let errorResult = TradeItErrorResult()
-                    errorResult.systemMessage = "Failed to save linked login to keychain"
-                    onFailure(errorResult)
+                    onFailure(TradeItErrorResult(
+                        title: "Keychain error",
+                        message: "Failed to save the linked login to the keychain"
+                    ))
                 }
             default:
-                onFailure(TradeItErrorResult.tradeErrorWithSystemMessage("Unknown error linking broker"))
+                onFailure(TradeItErrorResult(title: "Keychain error"))
             }
         }
     }
@@ -134,12 +136,12 @@ import PromiseKit
                     linkedBroker.linkedLogin = linkedLogin
                     onSuccess(linkedBroker: linkedBroker)
                 } else {
-                    let error = TradeItErrorResult.tradeErrorWithSystemMessage("Failed to update linked login to keychain")
+                    let error = TradeItErrorResult(title: "Keychain error", message: "Failed to update linked login in the keychain")
                     linkedBroker.error = error
                     onFailure(error)
                 }
             default:
-                let error = TradeItErrorResult.tradeErrorWithSystemMessage("Failed to update user token")
+                let error = TradeItErrorResult(title: "Keychain error")
                 linkedBroker.error = error
                 onFailure(error)
             }

--- a/TradeItIosTicketSDK2/TradeItLoginViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItLoginViewController.swift
@@ -54,37 +54,33 @@ class TradeItLoginViewController: KeyboardViewController {
 
         self.disableLinkButton()
         
-        let tradeItAuthenticationInfo = TradeItAuthenticationInfo(id: self.userNameInput.text,
-                                                                  andPassword: self.passwordInput.text,
-                                                                  andBroker: brokerShortName)
+        let tradeItAuthenticationInfo = TradeItAuthenticationInfo(
+            id: self.userNameInput.text,
+            andPassword: self.passwordInput.text,
+            andBroker: brokerShortName
+        )
         
         if let linkedBrokerToRelink = self.linkedBrokerToRelink {
-            self.linkedBrokerManager.relinkBroker(linkedBrokerToRelink,
-                                                  authInfo: tradeItAuthenticationInfo,
-                                                  onSuccess: { (linkedBroker: TradeItLinkedBroker) -> Void in
-                                                      self.authenticateBroker(linkedBroker)
-                                                  },
-                                                  onFailure: {(tradeItErrorResult: TradeItErrorResult) -> Void in
-                                                      self.activityIndicator.stopAnimating()
-                                                      self.enableLinkButton()
-                                                      self.alertManager.showGenericError(
-                                                          tradeItErrorResult: tradeItErrorResult,
-                                                          onViewController: self
-                                                      )
-                                                  })
+            self.linkedBrokerManager.relinkBroker(
+                linkedBrokerToRelink,
+                authInfo: tradeItAuthenticationInfo,
+                onSuccess: self.authenticateBroker,
+                onFailure: { error in
+                    self.activityIndicator.stopAnimating()
+                    self.enableLinkButton()
+                    self.alertManager.showError(error, onViewController: self)
+                }
+            )
         } else {
-            self.linkedBrokerManager.linkBroker(authInfo: tradeItAuthenticationInfo,
-                                                onSuccess: {(linkedBroker: TradeItLinkedBroker) -> Void in
-                                                    self.authenticateBroker(linkedBroker)
-                                                },
-                                                onFailure: {(tradeItErrorResult: TradeItErrorResult) -> Void in
-                                                    self.activityIndicator.stopAnimating()
-                                                    self.enableLinkButton()
-                                                    self.alertManager.showGenericError(
-                                                        tradeItErrorResult: tradeItErrorResult,
-                                                        onViewController: self
-                                                    )
-                                                })
+            self.linkedBrokerManager.linkBroker(
+                authInfo: tradeItAuthenticationInfo,
+                onSuccess: self.authenticateBroker,
+                onFailure: { error in
+                    self.activityIndicator.stopAnimating()
+                    self.enableLinkButton()
+                    self.alertManager.showError(error, onViewController: self)
+                }
+            )
         }
     }
 
@@ -108,23 +104,21 @@ class TradeItLoginViewController: KeyboardViewController {
             onSecurityQuestion: { (securityQuestion: TradeItSecurityQuestionResult, answerSecurityQuestion: (String) -> Void, cancelSecurityQuestion: () -> Void) -> Void in
                 self.activityIndicator.stopAnimating()
                 self.enableLinkButton()
-                self.alertManager.show(
-                    securityQuestion: securityQuestion,
+                self.alertManager.promptUserToAnswerSecurityQuestion(
+                    securityQuestion,
                     onViewController: self,
                     onAnswerSecurityQuestion: answerSecurityQuestion,
                     onCancelSecurityQuestion: cancelSecurityQuestion
                 )
             },
-            onFailure: { (tradeItErrorResult: TradeItErrorResult) -> Void in
+            onFailure: { error in
                 self.linkedBrokerManager.unlinkBroker(linkedBroker)
                 self.activityIndicator.stopAnimating()
                 self.enableLinkButton()
-                self.alertManager.showGenericError(tradeItErrorResult: tradeItErrorResult, onViewController: self)
+                self.alertManager.showError(error, onViewController: self)
             }
         )
     }
-
-    
 
     private func updateLinkButton() {
         if (self.userNameInput.text != "" && self.passwordInput.text != "" && !self.linkButton.enabled) {

--- a/TradeItIosTicketSDK2/TradeItMarketService.swift
+++ b/TradeItIosTicketSDK2/TradeItMarketService.swift
@@ -20,7 +20,7 @@ class TradeItMarketService {
             } else if let errorResult = tradeItResult as? TradeItErrorResult {
                 onFailure(errorResult)
             } else {
-                onFailure(TradeItErrorResult.tradeErrorWithSystemMessage("Error loading market data quote. Please try again later."))
+                onFailure(TradeItErrorResult(title: "Market Data failed", message: "Fetching the quote failed. Please try again later."))
             }
         })
     }
@@ -38,7 +38,7 @@ class TradeItMarketService {
             } else if let errorResult = tradeItResult as? TradeItErrorResult {
                 onFailure(errorResult)
             } else {
-                onFailure(TradeItErrorResult.tradeErrorWithSystemMessage("Error loading market data symbolLookup. Please try again later."))
+                onFailure(TradeItErrorResult(title: "Market Data failed", message: "Fetching data for symbol lookup failed. Please try again later."))
             }
         })
     }

--- a/TradeItIosTicketSDK2/TradeItOrder.swift
+++ b/TradeItIosTicketSDK2/TradeItOrder.swift
@@ -51,9 +51,9 @@ public class TradeItOrder {
                            onFailure: (TradeItErrorResult) -> Void
         ) -> Void {
         guard let linkedBrokerAccount = linkedBrokerAccount else {
-            return onFailure(TradeItErrorResult.tradeErrorWithSystemMessage("A linked broker account must be set before you preview an order.")) }
+            return onFailure(TradeItErrorResult(title: "Linked Broker Account", message: "A linked broker account must be set before you preview an order.")) }
         guard let previewPresenter = TradeItOrderPreviewPresenter(order: self) else {
-            return onFailure(TradeItErrorResult.tradeErrorWithSystemMessage("There was a problem previewing your order. Please try again."))
+            return onFailure(TradeItErrorResult(title: "Preview failed", message: "There was a problem previewing your order. Please try again."))
         }
 
         linkedBrokerAccount.tradeService.previewTrade(previewPresenter.generateRequest(), withCompletionBlock: { result in
@@ -61,7 +61,7 @@ public class TradeItOrder {
             case let previewOrder as TradeItPreviewTradeResult:
                 onSuccess(previewOrder, self.generatePlaceOrderCallback(tradeService: linkedBrokerAccount.tradeService, previewOrder: previewOrder))
             case let errorResult as TradeItErrorResult: onFailure(errorResult)
-            default: onFailure(TradeItErrorResult.tradeErrorWithSystemMessage("There was a problem previewing your order. Please try again."))
+            default: onFailure(TradeItErrorResult(title: "Preview failed", message: "There was a problem previewing your order. Please try again."))
             }
         })
     }

--- a/TradeItIosTicketSDK2/TradeItPortfolioViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItPortfolioViewController.swift
@@ -44,10 +44,9 @@ class TradeItPortfolioViewController: TradeItViewController, TradeItPortfolioAcc
         self.linkedBrokerManager.authenticateAll(
             onSecurityQuestion: { (securityQuestion: TradeItSecurityQuestionResult, answerSecurityQuestion: (String) -> Void, cancelSecurityQuestion: () -> Void) in
                 self.ezLoadingActivityManager.hide()
-                self.alertManager.show(
-                    securityQuestion: securityQuestion,
+                self.alertManager.promptUserToAnswerSecurityQuestion(securityQuestion,
                     onViewController: self,
-                    onAnswerSecurityQuestion: { (answer: String) in
+                    onAnswerSecurityQuestion: { answer in
                         self.ezLoadingActivityManager.show(text: "Authenticating", disableUI: true)
                         answerSecurityQuestion(answer)
                     },
@@ -170,7 +169,7 @@ class TradeItPortfolioViewController: TradeItViewController, TradeItPortfolioAcc
     func reloadAccountWasTapped(withLinkedBroker linkedBroker: TradeItLinkedBroker) {
         self.ezLoadingActivityManager.show(text: "Authenticating", disableUI: true)
         linkedBroker.authenticate(
-            onSuccess: { () -> Void in
+            onSuccess: {
                 self.ezLoadingActivityManager.updateText(text: "Refreshing Accounts")
                     linkedBroker.refreshAccountBalances(
                         onFinished: {
@@ -178,18 +177,18 @@ class TradeItPortfolioViewController: TradeItViewController, TradeItPortfolioAcc
                             self.updatePortfolioScreen()
                     })
             },
-            onSecurityQuestion: { (securityQuestion: TradeItSecurityQuestionResult, answerSecurityQuestion: (String) -> Void, cancelSecurityQuestion: () -> Void) -> Void in
+            onSecurityQuestion: { securityQuestion, answerSecurityQuestion, cancelSecurityQuestion in
                 self.ezLoadingActivityManager.hide()
-                self.alertManager.show(
-                    securityQuestion: securityQuestion,
+                self.alertManager.promptUserToAnswerSecurityQuestion(
+                    securityQuestion,
                     onViewController: self,
                     onAnswerSecurityQuestion: answerSecurityQuestion,
                     onCancelSecurityQuestion: cancelSecurityQuestion
                 )
             },
-            onFailure: { (tradeItErrorResult: TradeItErrorResult) -> Void in
+            onFailure: { error in
                 self.ezLoadingActivityManager.hide()
-                self.alertManager.show(tradeItErrorResult: tradeItErrorResult, onViewController: self, withLinkedBroker: linkedBroker, onFinished: {})
+                self.alertManager.showRelinkError(error, withLinkedBroker: linkedBroker, onViewController: self, onFinished: {})
             }
         )
     }

--- a/TradeItIosTicketSDK2/TradeItSelectBrokerViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItSelectBrokerViewController.swift
@@ -18,16 +18,18 @@ class TradeItSelectBrokerViewController: TradeItViewController, UITableViewDeleg
         ezLoadingActivityManager.show(text: "Loading Brokers", disableUI: true)
 
         self.linkedBrokerManager.getAvailableBrokers(
-            onSuccess: { (availableBrokers: [TradeItBroker]) -> Void in
+            onSuccess: { availableBrokers in
                 self.brokers = availableBrokers
                 self.ezLoadingActivityManager.hide()
                 self.brokerTable.reloadData()
             },
             onFailure: { () -> Void in
-                self.alertManager.showOn(viewController: self,
-                                         withAlertTitle: "Could not fetch brokers",
-                                         withAlertMessage: "Could not fetch the brokers list. Please try again later.",
-                                         withAlertActionTitle: "OK")
+                self.alertManager.showAlert(
+                    onViewController: self,
+                    withTitle: "Could not fetch brokers",
+                    withMessage: "Could not fetch the brokers list. Please try again later.",
+                    withActionTitle: "OK"
+                )
                 self.ezLoadingActivityManager.hide()
             }
         )

--- a/TradeItIosTicketSDK2/TradeItTradePreviewViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItTradePreviewViewController.swift
@@ -67,13 +67,13 @@ class TradeItTradePreviewViewController: TradeItViewController, UITableViewDeleg
         placeOrderCallback(onSuccess: { result in
             self.ezLoadingActivityManager.hide()
             self.delegate?.tradeItTradePreviewViewController(self, didPlaceOrderWithResult: result)
-            
-        }, onFailure: { errorResult in
+        }, onFailure: { error in
             self.ezLoadingActivityManager.hide()
-            self.alertManager.show(tradeItErrorResult: errorResult,
-                                            onViewController: self,
-                                            withLinkedBroker: self.linkedBrokerAccount.linkedBroker,
-                                            onFinished: {})
+            self.alertManager.showRelinkError(error,
+                withLinkedBroker: self.linkedBrokerAccount.linkedBroker,
+                onViewController: self,
+                onFinished: {} // TODO: Retry?
+            )
         })
     }
 

--- a/TradeItIosTicketSDK2/TradeItTradingTicketViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItTradingTicketViewController.swift
@@ -99,9 +99,18 @@ class TradeItTradingTicketViewController: TradeItViewController, TradeItSymbolSe
                 previewOrder: previewOrder,
                 placeOrderCallback: placeOrderCallback)
             
-        }, onFailure: { errorResult in
+        }, onFailure: { error in
+            guard let linkedBroker = self.order.linkedBrokerAccount?.linkedBroker else {
+                return assertionFailure("TradeItIosTicketSDK ERROR: TradeItTradingTicketViewController loaded without setting linkedBrokerAccount on order.")
+            }
             self.ezLoadingActivityManager.hide()
-            self.alertManager.show(tradeItErrorResult: errorResult, onViewController: self, withLinkedBroker: self.order.linkedBrokerAccount!.linkedBroker, onFinished: {})
+
+            self.alertManager.showRelinkError(
+                error,
+                withLinkedBroker: linkedBroker,
+                onViewController: self,
+                onFinished: {} // TODO: Retry?
+            )
         })
     }
 


### PR DESCRIPTION
Using `systemMessage` on a `TradeItErrorResult` was useless in the cases I was using them. I created a new convenience initializer for errors to be displayed to the user and converted my system message errors to use it.