### PR TITLE
[#125953915] Send SDK version # with every request

### DIFF
--- a/ExampleApp/ExampleViewController.swift
+++ b/ExampleApp/ExampleViewController.swift
@@ -689,8 +689,7 @@ class ExampleViewController: UIViewController, UITableViewDataSource, UITableVie
         let appDomain = Bundle.main.bundleIdentifier
         UserDefaults.standard.removePersistentDomain(forName: appDomain!)
 
-        let connector = TradeItConnector(apiKey: AppDelegate.API_KEY)
-        connector.environment = AppDelegate.ENVIRONMENT
+        let connector = TradeItConnector(apiKey: AppDelegate.API_KEY, environment: AppDelegate.ENVIRONMENT, version: TradeItEmsApiVersion_2)
 
         let linkedLogins = connector.getLinkedLogins() as! [TradeItLinkedLogin]
 

--- a/ExampleApp/Info.plist
+++ b/ExampleApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.16</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1.1.16</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/ExampleAppObjC/Info.plist
+++ b/ExampleAppObjC/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.16</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1.1.16</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/ExampleAppUITests/Info.plist
+++ b/ExampleAppUITests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.16</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1.1.16</string>
 </dict>
 </plist>

--- a/TradeItIosEmsApi/TradeItBalanceService.m
+++ b/TradeItIosEmsApi/TradeItBalanceService.m
@@ -26,9 +26,9 @@
        withCompletionBlock:(void (^)(TradeItResult *))completionBlock {
     request.token = self.session.token;
 
-    NSMutableURLRequest *balanceRequest = [TradeItRequestResultFactory buildJsonRequestForModel:request
-                                                                                      emsAction:@"balance/getAccountOverview"
-                                                                                    environment:self.session.connector.environment];
+    NSURLRequest *balanceRequest = [TradeItRequestResultFactory buildJsonRequestForModel:request
+                                                                               emsAction:@"balance/getAccountOverview"
+                                                                             environment:self.session.connector.environment];
 
     [self.session.connector sendEMSRequest:balanceRequest
                             forResultClass:[TradeItAccountOverviewResult class]

--- a/TradeItIosEmsApi/TradeItConnector.h
+++ b/TradeItIosEmsApi/TradeItConnector.h
@@ -37,8 +37,6 @@
  */
 @property TradeItEmsApiVersion version;
 
-- (nonnull id)initWithApiKey:(nonnull NSString *)apiKey;
-
 - (nonnull id)initWithApiKey:(nonnull NSString *)apiKey
                  environment:(TradeitEmsEnvironments)environment
                      version:(TradeItEmsApiVersion)version;

--- a/TradeItIosEmsApi/TradeItConnector.h
+++ b/TradeItIosEmsApi/TradeItConnector.h
@@ -120,10 +120,10 @@
  *  Method used by the session and services to issue requests to the ems servers
  *  You shouldn't need to call this method directly
  */
-- (void)sendEMSRequest:(NSMutableURLRequest * _Nullable)request
+- (void)sendEMSRequest:(NSURLRequest * _Nullable)request
    withCompletionBlock:(void (^ _Nullable)(TradeItResult * _Nullable, NSMutableString * _Nullable))completionBlock;
 
-- (void)sendEMSRequest:(NSMutableURLRequest * _Nullable)request
+- (void)sendEMSRequest:(NSURLRequest * _Nullable)request
         forResultClass:(Class _Nonnull)resultClass
    withCompletionBlock:(void (^ _Nullable)(TradeItResult * _Nullable))completionBlock;
 

--- a/TradeItIosEmsApi/TradeItConnector.m
+++ b/TradeItIosEmsApi/TradeItConnector.m
@@ -23,6 +23,7 @@
 #import "TradeItOAuthLoginPopupUrlForTokenUpdateResult.h"
 #import "TradeItOAuthDeleteLinkRequest.h"
 #import "TradeItParseErrorResult.h"
+#import "UserAgent.h"
 
 #ifdef CARTHAGE
 #import <TradeItIosTicketSDK2Carthage/TradeItIosTicketSDK2Carthage-Swift.h>
@@ -36,7 +37,6 @@
 - (void)oAuthDeleteLink:(TradeItLinkedLogin *)linkedLogin;
 
 @end
-
 
 @implementation TradeItConnector {
     BOOL runAsyncCompletionBlockOnMainThread;
@@ -433,6 +433,9 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^(void) {
         NSURLSession *session = [NSURLSession sharedSession];
+        NSString* userAgent = [UserAgent getUserAgent];
+        [request addValue:userAgent forHTTPHeaderField:@"User-Agent"];
+
         [[session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
               NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
               if ((data == nil) || ([httpResponse statusCode] != 200)) {

--- a/TradeItIosEmsApi/TradeItConnector.m
+++ b/TradeItIosEmsApi/TradeItConnector.m
@@ -40,6 +40,7 @@
 
 @implementation TradeItConnector {
     BOOL runAsyncCompletionBlockOnMainThread;
+    NSString* userAgent;
 }
 
 NSString *BROKER_LIST_KEYNAME = @"TRADEIT_BROKERS";
@@ -66,24 +67,11 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
         self.environment = environment;
         self.version = version;
         runAsyncCompletionBlockOnMainThread = true;
+        userAgent = [UserAgent getUserAgent];
     }
 
     return self;
 }
-
-- (id)initWithApiKey:(NSString *)apiKey {
-    self = [super init];
-
-    if (self) {
-        self.apiKey = apiKey;
-        self.environment = TradeItEmsProductionEnv;
-        self.version = TradeItEmsApiVersion_2;
-        runAsyncCompletionBlockOnMainThread = true;
-    }
-
-    return self;
-}
-
 
 - (void)getOAuthLoginPopupUrlForMobileWithBroker:(NSString *)broker
                                 oAuthCallbackUrl:(NSURL *)oAuthCallbackUrl
@@ -433,7 +421,6 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^(void) {
         NSURLSession *session = [NSURLSession sharedSession];
-        NSString* userAgent = [UserAgent getUserAgent];
         [request addValue:userAgent forHTTPHeaderField:@"User-Agent"];
 
         [[session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {

--- a/TradeItIosEmsApi/TradeItConnector.m
+++ b/TradeItIosEmsApi/TradeItConnector.m
@@ -23,7 +23,6 @@
 #import "TradeItOAuthLoginPopupUrlForTokenUpdateResult.h"
 #import "TradeItOAuthDeleteLinkRequest.h"
 #import "TradeItParseErrorResult.h"
-#import "TradeItUserAgentProvider.h"
 
 #ifdef CARTHAGE
 #import <TradeItIosTicketSDK2Carthage/TradeItIosTicketSDK2Carthage-Swift.h>
@@ -40,7 +39,6 @@
 
 @implementation TradeItConnector {
     BOOL runAsyncCompletionBlockOnMainThread;
-    NSString* userAgent;
 }
 
 NSString *BROKER_LIST_KEYNAME = @"TRADEIT_BROKERS";
@@ -67,7 +65,6 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
         self.environment = environment;
         self.version = version;
         runAsyncCompletionBlockOnMainThread = true;
-        userAgent = [TradeItUserAgentProvider getUserAgent];
     }
 
     return self;
@@ -421,7 +418,6 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^(void) {
         NSURLSession *session = [NSURLSession sharedSession];
-        [request addValue:userAgent forHTTPHeaderField:@"User-Agent"];
 
         [[session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
               NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;

--- a/TradeItIosEmsApi/TradeItConnector.m
+++ b/TradeItIosEmsApi/TradeItConnector.m
@@ -23,7 +23,7 @@
 #import "TradeItOAuthLoginPopupUrlForTokenUpdateResult.h"
 #import "TradeItOAuthDeleteLinkRequest.h"
 #import "TradeItParseErrorResult.h"
-#import "UserAgent.h"
+#import "TradeItUserAgentProvider.h"
 
 #ifdef CARTHAGE
 #import <TradeItIosTicketSDK2Carthage/TradeItIosTicketSDK2Carthage-Swift.h>
@@ -67,7 +67,7 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
         self.environment = environment;
         self.version = version;
         runAsyncCompletionBlockOnMainThread = true;
-        userAgent = [UserAgent getUserAgent];
+        userAgent = [TradeItUserAgentProvider getUserAgent];
     }
 
     return self;

--- a/TradeItIosEmsApi/TradeItConnector.m
+++ b/TradeItIosEmsApi/TradeItConnector.m
@@ -79,9 +79,9 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
                                                                  broker:broker
                                                 interAppAddressCallback:[oAuthCallbackUrl absoluteString]];
 
-    NSMutableURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:oAuthLoginPopupUrlForMobileRequest
-                                                                               emsAction:@"user/getOAuthLoginPopupUrlForMobile"
-                                                                             environment:self.environment];
+    NSURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:oAuthLoginPopupUrlForMobileRequest
+                                                                        emsAction:@"user/getOAuthLoginPopupUrlForMobile"
+                                                                      environment:self.environment];
 
     [self sendEMSRequest:request
      withCompletionBlock:^(TradeItResult *tradeItResult, NSMutableString *jsonResponse) {
@@ -107,9 +107,9 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
                                                                       userId:userId
                                                      interAppAddressCallback:[oAuthCallbackUrl absoluteString]];
 
-    NSMutableURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:oAuthLoginPopupUrlForTokenUpdateRequest
-                                                                               emsAction:@"user/getOAuthLoginPopupURLForTokenUpdate"
-                                                                             environment:self.environment];
+    NSURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:oAuthLoginPopupUrlForTokenUpdateRequest
+                                                                        emsAction:@"user/getOAuthLoginPopupURLForTokenUpdate"
+                                                                      environment:self.environment];
 
     [self sendEMSRequest:request
      withCompletionBlock:^(TradeItResult *tradeItResult, NSMutableString *jsonResponse) {
@@ -132,9 +132,9 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
     = [[TradeItOAuthAccessTokenRequest alloc] initWithApiKey:self.apiKey
                                                oAuthVerifier:oAuthVerifier];
 
-    NSMutableURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:oAuthAccessTokenRequest
-                                                                               emsAction:@"user/getOAuthAccessToken"
-                                                                             environment:self.environment];
+    NSURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:oAuthAccessTokenRequest
+                                                                        emsAction:@"user/getOAuthAccessToken"
+                                                                      environment:self.environment];
 
     [self sendEMSRequest:request
      withCompletionBlock:^(TradeItResult *tradeItResult, NSMutableString *jsonResponse) {
@@ -161,9 +161,9 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
     TradeItBrokerListRequest *brokerListRequest = [[TradeItBrokerListRequest alloc] initWithApiKey:self.apiKey
                                                                                    userCountryCode:userCountryCode];
 
-    NSMutableURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:brokerListRequest
-                                                                               emsAction:@"preference/getBrokerList"
-                                                                             environment:self.environment];
+    NSURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:brokerListRequest
+                                                                        emsAction:@"preference/getBrokerList"
+                                                                      environment:self.environment];
 
     [self sendEMSRequest:request forResultClass:[TradeItBrokerListResult class] withCompletionBlock:^(TradeItResult *result) {
         if ([result isKindOfClass: [TradeItBrokerListResult class]]) {
@@ -182,9 +182,9 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
                       andCompletionBlock:(void (^)(TradeItResult *))completionBlock {
     TradeItAuthLinkRequest *authLinkRequest = [[TradeItAuthLinkRequest alloc] initWithAuthInfo:authInfo andAPIKey:self.apiKey];
 
-    NSMutableURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:authLinkRequest
-                                                                               emsAction:@"user/oAuthLink"
-                                                                             environment:self.environment];
+    NSURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:authLinkRequest
+                                                                        emsAction:@"user/oAuthLink"
+                                                                      environment:self.environment];
 
     [self sendEMSRequest:request
      withCompletionBlock:^(TradeItResult *tradeItResult, NSMutableString *jsonResponse) {
@@ -207,9 +207,9 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
                                                                                           authInfo:authInfo
                                                                                             apiKey:self.apiKey];
 
-    NSMutableURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:updateLinkRequest
-                                                                               emsAction:@"user/oAuthUpdate"
-                                                                             environment:self.environment];
+    NSURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:updateLinkRequest
+                                                                        emsAction:@"user/oAuthUpdate"
+                                                                      environment:self.environment];
 
     [self sendEMSRequest:request
      withCompletionBlock:^(TradeItResult *tradeItResult, NSMutableString *jsonResponse) {
@@ -386,29 +386,34 @@ NSString *USER_DEFAULTS_SUITE = @"TRADEIT";
     oAuthDeleteLinkRequest.userId = linkedLogin.userId;
     oAuthDeleteLinkRequest.userToken = userToken;
 
-    NSMutableURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:oAuthDeleteLinkRequest
-                                                                               emsAction:@"user/oAuthDelete"
-                                                                             environment:self.environment];
+    NSURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:oAuthDeleteLinkRequest
+                                                                        emsAction:@"user/oAuthDelete"
+                                                                      environment:self.environment];
 
-    [self sendEMSRequest:request withCompletionBlock:^(TradeItResult * __unused tradeItResult, NSMutableString * __unused jsonResponse) {}];
+    [self sendEMSRequest:request
+     withCompletionBlock:^(TradeItResult * __unused tradeItResult, NSMutableString * __unused jsonResponse) {}];
 }
 
--(void) sendEMSRequest:(NSMutableURLRequest *)request
+-(void) sendEMSRequest:(NSURLRequest *)request
    withCompletionBlock:(void (^)(TradeItResult *, NSMutableString *))completionBlock {
-    [self sendEMSRequestReturnJSON:request forResultClass:[TradeItResult class] withCompletionBlock:completionBlock];
+    [self sendEMSRequestReturnJSON:request
+                    forResultClass:[TradeItResult class]
+               withCompletionBlock:completionBlock];
 }
 
-- (void)sendEMSRequest:(NSMutableURLRequest *)request
+- (void)sendEMSRequest:(NSURLRequest *)request
         forResultClass:(Class)ResultClass
    withCompletionBlock:(void (^)(TradeItResult *))completionBlock {
-    [self sendEMSRequestReturnJSON:request forResultClass:ResultClass withCompletionBlock:^(TradeItResult *result, NSMutableString * __unused jsonResponse) {
+    [self sendEMSRequestReturnJSON:request
+                    forResultClass:ResultClass
+               withCompletionBlock:^(TradeItResult *result, NSMutableString * __unused jsonResponse) {
         completionBlock(result);
     }];
 }
 
-- (void)sendEMSRequestReturnJSON:(NSMutableURLRequest *)request
-        forResultClass:(Class _Nonnull)ResultClass
-   withCompletionBlock:(void (^)(TradeItResult *, NSMutableString *))completionBlock {
+- (void)sendEMSRequestReturnJSON:(NSURLRequest *)request
+                  forResultClass:(Class _Nonnull)ResultClass
+             withCompletionBlock:(void (^)(TradeItResult *, NSMutableString *))completionBlock {
     /*
      NSLog(@"----------New Request----------");
      NSLog([[request URL] absoluteString]);

--- a/TradeItIosEmsApi/TradeItIosEmsApiLib.h
+++ b/TradeItIosEmsApi/TradeItIosEmsApiLib.h
@@ -85,5 +85,6 @@
 
 // EMS API Util classes
 #import "TradeItTypeDefs.h"
+#import "TradeItUserAgentProvider.h"
 
 #endif

--- a/TradeItIosEmsApi/TradeItMarketDataService.m
+++ b/TradeItIosEmsApi/TradeItMarketDataService.m
@@ -37,9 +37,9 @@
         return;
     }
 
-    NSMutableURLRequest *quoteRequest = [TradeItRequestResultFactory buildJsonRequestForModel:request
-                                                                                    emsAction:endpoint
-                                                                                  environment:self.connector.environment];
+    NSURLRequest *quoteRequest = [TradeItRequestResultFactory buildJsonRequestForModel:request
+                                                                             emsAction:endpoint
+                                                                           environment:self.connector.environment];
 
     [self.connector sendEMSRequest:quoteRequest
                     forResultClass:[TradeItQuotesResult class]
@@ -48,9 +48,9 @@
 }
 
 - (void)symbolLookup:(TradeItSymbolLookupRequest *)request withCompletionBlock:(void (^)(TradeItResult *))completionBlock {
-    NSMutableURLRequest *symbolLookupRequest = [TradeItRequestResultFactory buildJsonRequestForModel:request
-                                                                                           emsAction:@"marketdata/symbolLookup"
-                                                                                         environment:self.connector.environment];
+    NSURLRequest *symbolLookupRequest = [TradeItRequestResultFactory buildJsonRequestForModel:request
+                                                                                    emsAction:@"marketdata/symbolLookup"
+                                                                                  environment:self.connector.environment];
 
     [self.connector sendEMSRequest:symbolLookupRequest
                     forResultClass:[TradeItSymbolLookupResult class]

--- a/TradeItIosEmsApi/TradeItPositionService.m
+++ b/TradeItIosEmsApi/TradeItPositionService.m
@@ -23,9 +23,9 @@
 - (void) getAccountPositions:(TradeItGetPositionsRequest *) request withCompletionBlock:(void (^)(TradeItResult *)) completionBlock {
     request.token = self.session.token;
     
-    NSMutableURLRequest *positionRequest = [TradeItRequestResultFactory buildJsonRequestForModel:request
-                                                                                       emsAction:@"position/getPositions"
-                                                                                     environment:self.session.connector.environment];
+    NSURLRequest *positionRequest = [TradeItRequestResultFactory buildJsonRequestForModel:request
+                                                                                emsAction:@"position/getPositions"
+                                                                              environment:self.session.connector.environment];
 
     [self.session.connector sendEMSRequest:positionRequest
                             forResultClass:[TradeItGetPositionsResult class]

--- a/TradeItIosEmsApi/TradeItRequestResultFactory.h
+++ b/TradeItIosEmsApi/TradeItRequestResultFactory.h
@@ -12,9 +12,9 @@
 
 @property (class) id<RequestFactory> _Nullable requestFactory;
 
-+ (NSMutableURLRequest *)buildJsonRequestForModel:(JSONModel *)requestObject
-                                        emsAction:(NSString *)action
-                                      environment:(TradeitEmsEnvironments)env;
++ (NSURLRequest *)buildJsonRequestForModel:(JSONModel *)requestObject
+                                 emsAction:(NSString *)action
+                               environment:(TradeitEmsEnvironments)env;
 
 
 + (TradeItResult *)buildResult:(TradeItResult *)tradeItResult

--- a/TradeItIosEmsApi/TradeItRequestResultFactory.m
+++ b/TradeItIosEmsApi/TradeItRequestResultFactory.m
@@ -2,6 +2,7 @@
 #import "TradeItRequestResultFactory.h"
 #import "TradeItErrorResult.h"
 #import "TradeItParseErrorResult.h"
+#import "TradeItUserAgentProvider.h"
 
 @implementation TradeItRequestResultFactory
 
@@ -74,6 +75,8 @@ static id<RequestFactory> _requestFactory = nil;
 + (NSURLRequest *)buildJsonRequestForModel:(JSONModel *)requestObject
                                         emsAction:(NSString *)emsAction
                                       environment:(TradeitEmsEnvironments)env {
+    NSString *userAgent = [TradeItUserAgentProvider getUserAgent];
+
     NSString *requestJsonString = [requestObject toJSONString];
 
     NSURL *url = [NSURL URLWithString:emsAction
@@ -81,14 +84,15 @@ static id<RequestFactory> _requestFactory = nil;
 
     NSDictionary *headers = @{
                               @"Accept": @"application/json",
-                              @"Content-Type": @"application/json"
+                              @"Content-Type": @"application/json",
+                              @"User-Agent": userAgent
                               };
 
     NSURLRequest *request = [TradeItRequestResultFactory.requestFactory buildPostRequestForUrl:url
                                                                                   jsonPostBody:requestJsonString
                                                                                        headers:headers];
 
-    return request; //(NSMutableURLRequest *)[request mutableCopy];
+    return request;
 }
 
 + (TradeItResult *)buildResult:(TradeItResult *)tradeItResult

--- a/TradeItIosEmsApi/TradeItSession.m
+++ b/TradeItIosEmsApi/TradeItSession.m
@@ -40,10 +40,10 @@
                                                                                               andApiKey:self.connector.apiKey
                                                                                        andAdvertisingId:[self getAdvertisingId]];
 
-    NSMutableURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:authRequest
-                                                                               emsAction:@"user/authenticate"
-                                                                             environment:self.connector.environment];
-    
+    NSURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:authRequest
+                                                                        emsAction:@"user/authenticate"
+                                                                      environment:self.connector.environment];
+
     [self.connector sendEMSRequest:request
                withCompletionBlock:^(TradeItResult *result, NSMutableString *jsonResponse) {
         completionBlock([self parseAuthResponse:result
@@ -63,9 +63,9 @@
            withCompletionBlock:(void (^)(TradeItResult *))completionBlock {
     TradeItSecurityQuestionRequest *secRequest = [[TradeItSecurityQuestionRequest alloc] initWithToken:self.token andAnswer:answer];
 
-    NSMutableURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:secRequest
-                                                                               emsAction:@"user/answerSecurityQuestion"
-                                                                             environment:self.connector.environment];
+    NSURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:secRequest
+                                                                        emsAction:@"user/answerSecurityQuestion"
+                                                                      environment:self.connector.environment];
 
     [self.connector sendEMSRequest:request
                withCompletionBlock:^(TradeItResult *result, NSMutableString *jsonResponse) {

--- a/TradeItIosEmsApi/TradeItTradeService.m
+++ b/TradeItIosEmsApi/TradeItTradeService.m
@@ -24,9 +24,9 @@
 - (void)previewTrade:(TradeItPreviewTradeRequest *)order withCompletionBlock:(void (^)(TradeItResult *)) completionBlock {
     order.token = self.session.token;
     
-    NSMutableURLRequest * request = [TradeItRequestResultFactory buildJsonRequestForModel:order
-                                                                                emsAction:@"order/previewStockOrEtfOrder"
-                                                                              environment:self.session.connector.environment];
+    NSURLRequest * request = [TradeItRequestResultFactory buildJsonRequestForModel:order
+                                                                         emsAction:@"order/previewStockOrEtfOrder"
+                                                                       environment:self.session.connector.environment];
 
     [self.session.connector sendEMSRequest:request
                             forResultClass:[TradeItPreviewTradeResult class]
@@ -36,9 +36,9 @@
 - (void)placeTrade:(TradeItPlaceTradeRequest *)order withCompletionBlock:(void (^)(TradeItResult *))completionBlock {
     order.token = self.session.token;
     
-    NSMutableURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:order
-                                                                               emsAction:@"order/placeStockOrEtfOrder"
-                                                                             environment:self.session.connector.environment];
+    NSURLRequest *request = [TradeItRequestResultFactory buildJsonRequestForModel:order
+                                                                        emsAction:@"order/placeStockOrEtfOrder"
+                                                                      environment:self.session.connector.environment];
 
     [self.session.connector sendEMSRequest:request
                             forResultClass:[TradeItPlaceTradeResult class]

--- a/TradeItIosEmsApi/TradeItUserAgentProvider.h
+++ b/TradeItIosEmsApi/TradeItUserAgentProvider.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
 
-@interface UserAgent : NSObject
+@interface TradeItUserAgentProvider : NSObject
 + (NSString *)getUserAgent;
 @end

--- a/TradeItIosEmsApi/TradeItUserAgentProvider.m
+++ b/TradeItIosEmsApi/TradeItUserAgentProvider.m
@@ -10,31 +10,36 @@
 
 @implementation TradeItUserAgentProvider
 
-
 + (NSString *)getUserAgent {
-    NSDictionary<NSString *, id> *bundleDict = [[NSBundle mainBundle] infoDictionary];
-    NSString *appName = [bundleDict valueForKey:@"CFBundleName"];
-    NSString *appVersion = [bundleDict valueForKey:@"CFBundleShortVersionString"];
-    
-    NSString * appDescriptor = [NSString stringWithFormat:@"%@/%@", appName, appVersion];
-    
-    UIDevice *device = [UIDevice currentDevice];
-    NSString* systemVersion = [device systemVersion];
-    
-    NSString * osDescriptor = [NSString stringWithFormat:@"%@ %@", @"iOS", systemVersion];
-    
-    NSString * hardwareString = [self getSysInfoByName:"hw.model"];
-    
-    NSDictionary<NSString *, id> * bundleProviderSDK2 = [[TradeItBundleProvider provide] infoDictionary];
-    
-    NSString *sdkName = [bundleProviderSDK2 valueForKey:@"CFBundleName"];
-    NSString *sdkVersion = [bundleProviderSDK2 valueForKey:@"CFBundleVersion"];
-    
-    return [NSString stringWithFormat:@"%@/%@ (%@) / %@/%@", appDescriptor,  osDescriptor, hardwareString, sdkName, sdkVersion];
+    static NSString *userAgent = nil;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        NSDictionary<NSString *, id> *bundleDict = [[NSBundle mainBundle] infoDictionary];
+        NSString *appName = [bundleDict valueForKey:@"CFBundleName"];
+        NSString *appVersion = [bundleDict valueForKey:@"CFBundleShortVersionString"];
+
+        NSString *appDescriptor = [NSString stringWithFormat:@"%@/%@", appName, appVersion];
+
+        UIDevice *device = [UIDevice currentDevice];
+        NSString *systemVersion = [device systemVersion];
+
+        NSString *osDescriptor = [NSString stringWithFormat:@"%@ %@", @"iOS", systemVersion];
+
+        NSString *hardwareString = [self getSysInfoByName:"hw.model"];
+
+        NSDictionary<NSString *, id> *bundleProviderSDK2 = [[TradeItBundleProvider provide] infoDictionary];
+
+        NSString *sdkName = [bundleProviderSDK2 valueForKey:@"CFBundleName"];
+        NSString *sdkVersion = [bundleProviderSDK2 valueForKey:@"CFBundleVersion"];
+
+        userAgent = [NSString stringWithFormat:@"%@/%@ (%@) / %@/%@", appDescriptor,  osDescriptor, hardwareString, sdkName, sdkVersion];
+    });
+
+    return userAgent;
 }
 
-+ (NSString *)getSysInfoByName:(char *)typeSpecifier
-{
++ (NSString *)getSysInfoByName:(char *)typeSpecifier {
     size_t size;
     sysctlbyname(typeSpecifier, NULL, &size, NULL, 0);
     

--- a/TradeItIosEmsApi/TradeItUserAgentProvider.m
+++ b/TradeItIosEmsApi/TradeItUserAgentProvider.m
@@ -1,4 +1,4 @@
-#import "UserAgent.h"
+#import "TradeItUserAgentProvider.h"
 #include <UIKit/UIKit.h>
 #include <sys/sysctl.h>
 
@@ -8,7 +8,7 @@
     #import <TradeItIosTicketSDK2/TradeItIosTicketSDK2-Swift.h>
 #endif
 
-@implementation UserAgent
+@implementation TradeItUserAgentProvider
 
 
 + (NSString *)getUserAgent {
@@ -33,7 +33,7 @@
     return [NSString stringWithFormat:@"%@/%@ (%@) / %@/%@", appDescriptor,  osDescriptor, hardwareString, sdkName, sdkVersion];
 }
 
-+ (NSString *) getSysInfoByName:(char *)typeSpecifier
++ (NSString *)getSysInfoByName:(char *)typeSpecifier
 {
     size_t size;
     sysctlbyname(typeSpecifier, NULL, &size, NULL, 0);

--- a/TradeItIosEmsApi/UserAgent.h
+++ b/TradeItIosEmsApi/UserAgent.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface UserAgent : NSObject
++ (NSString *)getUserAgent;
+@end

--- a/TradeItIosEmsApi/UserAgent.m
+++ b/TradeItIosEmsApi/UserAgent.m
@@ -19,8 +19,11 @@
     
     NSString * hardwareString = [self getSysInfoByName:"hw.model"];
     
-    NSString * version = @"TradeItIosTicketSDK2";
-    return [NSString stringWithFormat:@"%@/%@ (%@) / %@", appDescriptor,  osDescriptor, hardwareString, version];
+    NSDictionary<NSString *, id> *bundleSDK2 = [[NSBundle bundleWithIdentifier:@"TradeIt.TradeItIosTicketSDK2"] infoDictionary];
+    NSString *sdkName = [bundleSDK2 valueForKey:@"CFBundleName"];
+    NSString *sdkVersion = [bundleSDK2 valueForKey:@"CFBundleShortVersionString"];
+    
+    return [NSString stringWithFormat:@"%@/%@ (%@) / %@/%@", appDescriptor,  osDescriptor, hardwareString, sdkName, sdkVersion];
 }
 
 + (NSString *) getSysInfoByName:(char *)typeSpecifier

--- a/TradeItIosEmsApi/UserAgent.m
+++ b/TradeItIosEmsApi/UserAgent.m
@@ -28,7 +28,7 @@
     NSDictionary<NSString *, id> * bundleProviderSDK2 = [[TradeItBundleProvider provide] infoDictionary];
     
     NSString *sdkName = [bundleProviderSDK2 valueForKey:@"CFBundleName"];
-    NSString *sdkVersion = [bundleProviderSDK2 valueForKey:@"CFBundleShortVersionString"];
+    NSString *sdkVersion = [bundleProviderSDK2 valueForKey:@"CFBundleVersion"];
     
     return [NSString stringWithFormat:@"%@/%@ (%@) / %@/%@", appDescriptor,  osDescriptor, hardwareString, sdkName, sdkVersion];
 }

--- a/TradeItIosEmsApi/UserAgent.m
+++ b/TradeItIosEmsApi/UserAgent.m
@@ -1,0 +1,40 @@
+#import "UserAgent.h"
+#include <UIKit/UIKit.h>
+#include <sys/sysctl.h>
+
+@implementation UserAgent
+
+
++ (NSString *)getUserAgent {
+    NSDictionary<NSString *, id> *bundleDict = [[NSBundle mainBundle] infoDictionary];
+    NSString *appName = [bundleDict valueForKey:@"CFBundleName"];
+    NSString *appVersion = [bundleDict valueForKey:@"CFBundleShortVersionString"];
+    
+    NSString * appDescriptor = [NSString stringWithFormat:@"%@/%@", appName, appVersion];
+    
+    UIDevice *device = [UIDevice currentDevice];
+    NSString* systemVersion = [device systemVersion];
+    
+    NSString * osDescriptor = [NSString stringWithFormat:@"%@ %@", @"iOS", systemVersion];
+    
+    NSString * hardwareString = [self getSysInfoByName:"hw.model"];
+    
+    NSString * version = @"TradeItIosTicketSDK2";
+    return [NSString stringWithFormat:@"%@/%@ (%@) / %@", appDescriptor,  osDescriptor, hardwareString, version];
+}
+
++ (NSString *) getSysInfoByName:(char *)typeSpecifier
+{
+    size_t size;
+    sysctlbyname(typeSpecifier, NULL, &size, NULL, 0);
+    
+    char *answer = malloc(size);
+    sysctlbyname(typeSpecifier, answer, &size, NULL, 0);
+    
+    NSString *results = [NSString stringWithCString:answer encoding: NSUTF8StringEncoding];
+    
+    free(answer);
+    return results;
+}
+
+@end

--- a/TradeItIosEmsApi/UserAgent.m
+++ b/TradeItIosEmsApi/UserAgent.m
@@ -2,6 +2,12 @@
 #include <UIKit/UIKit.h>
 #include <sys/sysctl.h>
 
+#ifdef CARTHAGE
+    #import <TradeItIosTicketSDK2Carthage/TradeItIosTicketSDK2Carthage-Swift.h>
+#else
+    #import <TradeItIosTicketSDK2/TradeItIosTicketSDK2-Swift.h>
+#endif
+
 @implementation UserAgent
 
 
@@ -19,9 +25,10 @@
     
     NSString * hardwareString = [self getSysInfoByName:"hw.model"];
     
-    NSDictionary<NSString *, id> *bundleSDK2 = [[NSBundle bundleWithIdentifier:@"TradeIt.TradeItIosTicketSDK2"] infoDictionary];
-    NSString *sdkName = [bundleSDK2 valueForKey:@"CFBundleName"];
-    NSString *sdkVersion = [bundleSDK2 valueForKey:@"CFBundleShortVersionString"];
+    NSDictionary<NSString *, id> * bundleProviderSDK2 = [[TradeItBundleProvider provide] infoDictionary];
+    
+    NSString *sdkName = [bundleProviderSDK2 valueForKey:@"CFBundleName"];
+    NSString *sdkVersion = [bundleProviderSDK2 valueForKey:@"CFBundleShortVersionString"];
     
     return [NSString stringWithFormat:@"%@/%@ (%@) / %@/%@", appDescriptor,  osDescriptor, hardwareString, sdkName, sdkVersion];
 }

--- a/TradeItIosTicketSDK2.xcodeproj/project.pbxproj
+++ b/TradeItIosTicketSDK2.xcodeproj/project.pbxproj
@@ -384,6 +384,8 @@
 		B5FDB6811DDE40F700CA558D /* norton.png in Resources */ = {isa = PBXBuildFile; fileRef = B5FDB67F1DDE40F700CA558D /* norton.png */; };
 		B5FDB6821DDE40F700CA558D /* truste.png in Resources */ = {isa = PBXBuildFile; fileRef = B5FDB6801DDE40F700CA558D /* truste.png */; };
 		CBA8E0CD6C673C37283F6277 /* Pods_ExampleAppObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15D050ED253E2B66D47A6809 /* Pods_ExampleAppObjC.framework */; };
+		B58BC7271DDBBE260079ED8B /* UserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = B58BC7251DDBBE260079ED8B /* UserAgent.h */; };
+		B58BC7281DDBBE260079ED8B /* UserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7261DDBBE260079ED8B /* UserAgent.m */; };
 		D33505F61DC24EDE00BC5BC5 /* TradeItSDK2AlertQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33505F11DC24EDE00BC5BC5 /* TradeItSDK2AlertQueue.swift */; };
 		D33505F71DC24EDE00BC5BC5 /* TradeItSDK2UITestsAuthErrorFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33505F21DC24EDE00BC5BC5 /* TradeItSDK2UITestsAuthErrorFlow.swift */; };
 		D33505F81DC24EDE00BC5BC5 /* TradeItSDK2UITestsPortfolioFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33505F31DC24EDE00BC5BC5 /* TradeItSDK2UITestsPortfolioFlow.swift */; };
@@ -979,6 +981,8 @@
 		B5FDB67F1DDE40F700CA558D /* norton.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = norton.png; sourceTree = "<group>"; };
 		B5FDB6801DDE40F700CA558D /* truste.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = truste.png; sourceTree = "<group>"; };
 		BA2C2105E6203F11E285CA10 /* Pods-ExampleAppObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleAppObjC.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleAppObjC/Pods-ExampleAppObjC.debug.xcconfig"; sourceTree = "<group>"; };
+		B58BC7251DDBBE260079ED8B /* UserAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserAgent.h; sourceTree = "<group>"; };
+		B58BC7261DDBBE260079ED8B /* UserAgent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UserAgent.m; sourceTree = "<group>"; };
 		C7957FA237F8D3ABE3186EE3 /* Pods_TradeItIosTicketSDK2Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TradeItIosTicketSDK2Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CFA3D7027ABB635CCC657394 /* Pods-ExampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleApp/Pods-ExampleApp.debug.xcconfig"; sourceTree = "<group>"; };
 		D33505F11DC24EDE00BC5BC5 /* TradeItSDK2AlertQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItSDK2AlertQueue.swift; sourceTree = "<group>"; };
@@ -1444,6 +1448,8 @@
 				75BAAB391DB7EF2F00E5435C /* TradeItKeychain.h */,
 				75BAAB3A1DB7EF2F00E5435C /* TradeItKeychain.m */,
 				75BAAB6F1DB7EF2F00E5435C /* TradeItTypeDefs.h */,
+				B58BC7251DDBBE260079ED8B /* UserAgent.h */,
+				B58BC7261DDBBE260079ED8B /* UserAgent.m */,
 			);
 			path = TradeItIosEmsApi;
 			sourceTree = "<group>";
@@ -1690,6 +1696,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				75BAABB51DB7EF2F00E5435C /* TradeItGetPositionsResult.h in Headers */,
+				B58BC7271DDBBE260079ED8B /* UserAgent.h in Headers */,
 				75BAABB71DB7EF2F00E5435C /* TradeItIosEmsApiLib.h in Headers */,
 				7591A9111EFB09F0008EB943 /* TradeItFxOrderInfoResult.h in Headers */,
 				75AB474A1EFEEF5000A8BEC6 /* TradeItInstrumentOrderCapabilities.h in Headers */,
@@ -2530,6 +2537,7 @@
 				75BAAAE51DB7EEB400E5435C /* TradeItTradePreviewViewController.swift in Sources */,
 				75F426171E1EEBE00054E15F /* TradeItThemeConfigurator.swift in Sources */,
 				75BAAAD21DB7EEB400E5435C /* TradeItPortfolioPositionPresenter.swift in Sources */,
+				B58BC7281DDBBE260079ED8B /* UserAgent.m in Sources */,
 				75BAAB8C1DB7EF2F00E5435C /* TradeItAccountOverviewRequest.m in Sources */,
 				75BAAAE01DB7EEB400E5435C /* TradeItSymbolSearchViewController.swift in Sources */,
 				75BAABE91DB7EF2F00E5435C /* TradeItSymbolLookupCompany.m in Sources */,

--- a/TradeItIosTicketSDK2.xcodeproj/project.pbxproj
+++ b/TradeItIosTicketSDK2.xcodeproj/project.pbxproj
@@ -370,6 +370,8 @@
 		B55933F81DB8F78400620A57 /* TradeItViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55933F71DB8F78400620A57 /* TradeItViewController.swift */; };
 		B55CFDC41DB8FC9000DA2928 /* TradeItPreviewTradeOrderDetails+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55CFDC31DB8FC9000DA2928 /* TradeItPreviewTradeOrderDetails+Helpers.swift */; };
 		B55CFDC61DB9156800DA2928 /* TradeItOrderDetailsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55CFDC51DB9156800DA2928 /* TradeItOrderDetailsPresenter.swift */; };
+		B5719C171DDE616F000EE0BD /* UserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = B58BC7251DDBBE260079ED8B /* UserAgent.h */; };
+		B5719C181DDE6173000EE0BD /* UserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7261DDBBE260079ED8B /* UserAgent.m */; };
 		B57ABA301DBEA9C1009B82A3 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B57ABA2F1DBEA9C1009B82A3 /* LocalAuthentication.framework */; };
 		B57ABA321DBEAA39009B82A3 /* TradeItDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57ABA311DBEAA39009B82A3 /* TradeItDeviceManager.swift */; };
 		B58BC7241DDBA6780079ED8B /* TradeItWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7231DDBA6780079ED8B /* TradeItWebViewController.swift */; };
@@ -1776,6 +1778,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FC6E7A241DCD1F8B005225CC /* TradeItGetPositionsResult.h in Headers */,
+				B5719C171DDE616F000EE0BD /* UserAgent.h in Headers */,
 				FC6E7A251DCD1F8B005225CC /* TradeItIosEmsApiLib.h in Headers */,
 				7591A9121EFB09F0008EB943 /* TradeItFxOrderInfoResult.h in Headers */,
 				75AB474B1EFEEF5000A8BEC6 /* TradeItInstrumentOrderCapabilities.h in Headers */,
@@ -2711,6 +2714,7 @@
 				FC6E79F91DCD1F8B005225CC /* TradeItAccountManagementViewController.swift in Sources */,
 				FC6E79FA1DCD1F8B005225CC /* TradeItPreviewTradeResult.m in Sources */,
 				FC6E79FB1DCD1F8B005225CC /* TradeItWelcomeViewController.swift in Sources */,
+				B5719C181DDE6173000EE0BD /* UserAgent.m in Sources */,
 				FC6E79FC1DCD1F8B005225CC /* TradeItViewController.swift in Sources */,
 				FC6E79FD1DCD1F8B005225CC /* TradeItTradeService.m in Sources */,
 				FC6E79FE1DCD1F8B005225CC /* TradeItPreviewTradeRequest.m in Sources */,

--- a/TradeItIosTicketSDK2.xcodeproj/project.pbxproj
+++ b/TradeItIosTicketSDK2.xcodeproj/project.pbxproj
@@ -375,6 +375,8 @@
 		B57ABA301DBEA9C1009B82A3 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B57ABA2F1DBEA9C1009B82A3 /* LocalAuthentication.framework */; };
 		B57ABA321DBEAA39009B82A3 /* TradeItDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57ABA311DBEAA39009B82A3 /* TradeItDeviceManager.swift */; };
 		B58BC7241DDBA6780079ED8B /* TradeItWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7231DDBA6780079ED8B /* TradeItWebViewController.swift */; };
+		B58BC7271DDBBE260079ED8B /* UserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = B58BC7251DDBBE260079ED8B /* UserAgent.h */; };
+		B58BC7281DDBBE260079ED8B /* UserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7261DDBBE260079ED8B /* UserAgent.m */; };
 		B59904AD1EFAAA050044E1DE /* TradeItYahooPreviewOrderWarningTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59904AC1EFAAA050044E1DE /* TradeItYahooPreviewOrderWarningTableViewCell.swift */; };
 		B59904AE1EFAAA130044E1DE /* TradeItYahooPreviewOrderWarningTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59904AC1EFAAA050044E1DE /* TradeItYahooPreviewOrderWarningTableViewCell.swift */; };
 		B59904B01EFAAAD80044E1DE /* TradeItYahooPreviewOrderAcknowledgementTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59904AF1EFAAAD80044E1DE /* TradeItYahooPreviewOrderAcknowledgementTableViewCell.swift */; };
@@ -386,10 +388,6 @@
 		B5FDB6811DDE40F700CA558D /* norton.png in Resources */ = {isa = PBXBuildFile; fileRef = B5FDB67F1DDE40F700CA558D /* norton.png */; };
 		B5FDB6821DDE40F700CA558D /* truste.png in Resources */ = {isa = PBXBuildFile; fileRef = B5FDB6801DDE40F700CA558D /* truste.png */; };
 		CBA8E0CD6C673C37283F6277 /* Pods_ExampleAppObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15D050ED253E2B66D47A6809 /* Pods_ExampleAppObjC.framework */; };
-		B58BC7271DDBBE260079ED8B /* UserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = B58BC7251DDBBE260079ED8B /* UserAgent.h */; };
-		B58BC7281DDBBE260079ED8B /* UserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7261DDBBE260079ED8B /* UserAgent.m */; };
-		B5FDB6811DDE40F700CA558D /* norton.png in Resources */ = {isa = PBXBuildFile; fileRef = B5FDB67F1DDE40F700CA558D /* norton.png */; };
-		B5FDB6821DDE40F700CA558D /* truste.png in Resources */ = {isa = PBXBuildFile; fileRef = B5FDB6801DDE40F700CA558D /* truste.png */; };
 		D33505F61DC24EDE00BC5BC5 /* TradeItSDK2AlertQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33505F11DC24EDE00BC5BC5 /* TradeItSDK2AlertQueue.swift */; };
 		D33505F71DC24EDE00BC5BC5 /* TradeItSDK2UITestsAuthErrorFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33505F21DC24EDE00BC5BC5 /* TradeItSDK2UITestsAuthErrorFlow.swift */; };
 		D33505F81DC24EDE00BC5BC5 /* TradeItSDK2UITestsPortfolioFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33505F31DC24EDE00BC5BC5 /* TradeItSDK2UITestsPortfolioFlow.swift */; };
@@ -978,6 +976,8 @@
 		B57ABA2F1DBEA9C1009B82A3 /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
 		B57ABA311DBEAA39009B82A3 /* TradeItDeviceManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItDeviceManager.swift; sourceTree = "<group>"; };
 		B58BC7231DDBA6780079ED8B /* TradeItWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItWebViewController.swift; sourceTree = "<group>"; };
+		B58BC7251DDBBE260079ED8B /* UserAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserAgent.h; sourceTree = "<group>"; };
+		B58BC7261DDBBE260079ED8B /* UserAgent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UserAgent.m; sourceTree = "<group>"; };
 		B59904AC1EFAAA050044E1DE /* TradeItYahooPreviewOrderWarningTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItYahooPreviewOrderWarningTableViewCell.swift; sourceTree = "<group>"; };
 		B59904AF1EFAAAD80044E1DE /* TradeItYahooPreviewOrderAcknowledgementTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItYahooPreviewOrderAcknowledgementTableViewCell.swift; sourceTree = "<group>"; };
 		B59F0CC51EA69D3E00C0F56F /* TradeItSubtitleWithDetailsCellTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItSubtitleWithDetailsCellTableViewCell.swift; sourceTree = "<group>"; };
@@ -985,10 +985,6 @@
 		B5FDB67F1DDE40F700CA558D /* norton.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = norton.png; sourceTree = "<group>"; };
 		B5FDB6801DDE40F700CA558D /* truste.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = truste.png; sourceTree = "<group>"; };
 		BA2C2105E6203F11E285CA10 /* Pods-ExampleAppObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleAppObjC.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleAppObjC/Pods-ExampleAppObjC.debug.xcconfig"; sourceTree = "<group>"; };
-		B58BC7251DDBBE260079ED8B /* UserAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserAgent.h; sourceTree = "<group>"; };
-		B58BC7261DDBBE260079ED8B /* UserAgent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UserAgent.m; sourceTree = "<group>"; };
-		B5FDB67F1DDE40F700CA558D /* norton.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = norton.png; sourceTree = "<group>"; };
-		B5FDB6801DDE40F700CA558D /* truste.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = truste.png; sourceTree = "<group>"; };
 		C7957FA237F8D3ABE3186EE3 /* Pods_TradeItIosTicketSDK2Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TradeItIosTicketSDK2Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CFA3D7027ABB635CCC657394 /* Pods-ExampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleApp/Pods-ExampleApp.debug.xcconfig"; sourceTree = "<group>"; };
 		D33505F11DC24EDE00BC5BC5 /* TradeItSDK2AlertQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItSDK2AlertQueue.swift; sourceTree = "<group>"; };
@@ -2913,7 +2909,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 1.1.16;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -2969,7 +2965,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 1.1.16;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -3004,10 +3000,10 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1.1.16;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
-				INFOPLIST_FILE = "$(SRCROOT)/TradeItIosTicketSDK2/Info.plist";
+				INFOPLIST_FILE = TradeItIosTicketSDK2/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = TradeIt.TradeItIosTicketSDK2;
@@ -3029,11 +3025,11 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1.1.16;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_TESTABILITY = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
-				INFOPLIST_FILE = "$(SRCROOT)/TradeItIosTicketSDK2/Info.plist";
+				INFOPLIST_FILE = TradeItIosTicketSDK2/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = TradeIt.TradeItIosTicketSDK2;
@@ -3114,7 +3110,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1.1.16;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3147,7 +3143,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1.1.16;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/TradeItIosTicketSDK2.xcodeproj/project.pbxproj
+++ b/TradeItIosTicketSDK2.xcodeproj/project.pbxproj
@@ -388,6 +388,8 @@
 		CBA8E0CD6C673C37283F6277 /* Pods_ExampleAppObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15D050ED253E2B66D47A6809 /* Pods_ExampleAppObjC.framework */; };
 		B58BC7271DDBBE260079ED8B /* UserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = B58BC7251DDBBE260079ED8B /* UserAgent.h */; };
 		B58BC7281DDBBE260079ED8B /* UserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7261DDBBE260079ED8B /* UserAgent.m */; };
+		B5FDB6811DDE40F700CA558D /* norton.png in Resources */ = {isa = PBXBuildFile; fileRef = B5FDB67F1DDE40F700CA558D /* norton.png */; };
+		B5FDB6821DDE40F700CA558D /* truste.png in Resources */ = {isa = PBXBuildFile; fileRef = B5FDB6801DDE40F700CA558D /* truste.png */; };
 		D33505F61DC24EDE00BC5BC5 /* TradeItSDK2AlertQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33505F11DC24EDE00BC5BC5 /* TradeItSDK2AlertQueue.swift */; };
 		D33505F71DC24EDE00BC5BC5 /* TradeItSDK2UITestsAuthErrorFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33505F21DC24EDE00BC5BC5 /* TradeItSDK2UITestsAuthErrorFlow.swift */; };
 		D33505F81DC24EDE00BC5BC5 /* TradeItSDK2UITestsPortfolioFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33505F31DC24EDE00BC5BC5 /* TradeItSDK2UITestsPortfolioFlow.swift */; };
@@ -985,6 +987,8 @@
 		BA2C2105E6203F11E285CA10 /* Pods-ExampleAppObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleAppObjC.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleAppObjC/Pods-ExampleAppObjC.debug.xcconfig"; sourceTree = "<group>"; };
 		B58BC7251DDBBE260079ED8B /* UserAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserAgent.h; sourceTree = "<group>"; };
 		B58BC7261DDBBE260079ED8B /* UserAgent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UserAgent.m; sourceTree = "<group>"; };
+		B5FDB67F1DDE40F700CA558D /* norton.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = norton.png; sourceTree = "<group>"; };
+		B5FDB6801DDE40F700CA558D /* truste.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = truste.png; sourceTree = "<group>"; };
 		C7957FA237F8D3ABE3186EE3 /* Pods_TradeItIosTicketSDK2Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TradeItIosTicketSDK2Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CFA3D7027ABB635CCC657394 /* Pods-ExampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleApp/Pods-ExampleApp.debug.xcconfig"; sourceTree = "<group>"; };
 		D33505F11DC24EDE00BC5BC5 /* TradeItSDK2AlertQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItSDK2AlertQueue.swift; sourceTree = "<group>"; };

--- a/TradeItIosTicketSDK2.xcodeproj/project.pbxproj
+++ b/TradeItIosTicketSDK2.xcodeproj/project.pbxproj
@@ -370,13 +370,13 @@
 		B55933F81DB8F78400620A57 /* TradeItViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55933F71DB8F78400620A57 /* TradeItViewController.swift */; };
 		B55CFDC41DB8FC9000DA2928 /* TradeItPreviewTradeOrderDetails+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55CFDC31DB8FC9000DA2928 /* TradeItPreviewTradeOrderDetails+Helpers.swift */; };
 		B55CFDC61DB9156800DA2928 /* TradeItOrderDetailsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55CFDC51DB9156800DA2928 /* TradeItOrderDetailsPresenter.swift */; };
-		B5719C171DDE616F000EE0BD /* UserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = B58BC7251DDBBE260079ED8B /* UserAgent.h */; };
-		B5719C181DDE6173000EE0BD /* UserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7261DDBBE260079ED8B /* UserAgent.m */; };
+		B5719C171DDE616F000EE0BD /* TradeItUserAgentProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B58BC7251DDBBE260079ED8B /* TradeItUserAgentProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B5719C181DDE6173000EE0BD /* TradeItUserAgentProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7261DDBBE260079ED8B /* TradeItUserAgentProvider.m */; };
 		B57ABA301DBEA9C1009B82A3 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B57ABA2F1DBEA9C1009B82A3 /* LocalAuthentication.framework */; };
 		B57ABA321DBEAA39009B82A3 /* TradeItDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57ABA311DBEAA39009B82A3 /* TradeItDeviceManager.swift */; };
 		B58BC7241DDBA6780079ED8B /* TradeItWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7231DDBA6780079ED8B /* TradeItWebViewController.swift */; };
-		B58BC7271DDBBE260079ED8B /* UserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = B58BC7251DDBBE260079ED8B /* UserAgent.h */; };
-		B58BC7281DDBBE260079ED8B /* UserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7261DDBBE260079ED8B /* UserAgent.m */; };
+		B58BC7271DDBBE260079ED8B /* TradeItUserAgentProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B58BC7251DDBBE260079ED8B /* TradeItUserAgentProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B58BC7281DDBBE260079ED8B /* TradeItUserAgentProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B58BC7261DDBBE260079ED8B /* TradeItUserAgentProvider.m */; };
 		B59904AD1EFAAA050044E1DE /* TradeItYahooPreviewOrderWarningTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59904AC1EFAAA050044E1DE /* TradeItYahooPreviewOrderWarningTableViewCell.swift */; };
 		B59904AE1EFAAA130044E1DE /* TradeItYahooPreviewOrderWarningTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59904AC1EFAAA050044E1DE /* TradeItYahooPreviewOrderWarningTableViewCell.swift */; };
 		B59904B01EFAAAD80044E1DE /* TradeItYahooPreviewOrderAcknowledgementTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59904AF1EFAAAD80044E1DE /* TradeItYahooPreviewOrderAcknowledgementTableViewCell.swift */; };
@@ -976,8 +976,8 @@
 		B57ABA2F1DBEA9C1009B82A3 /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
 		B57ABA311DBEAA39009B82A3 /* TradeItDeviceManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItDeviceManager.swift; sourceTree = "<group>"; };
 		B58BC7231DDBA6780079ED8B /* TradeItWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItWebViewController.swift; sourceTree = "<group>"; };
-		B58BC7251DDBBE260079ED8B /* UserAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserAgent.h; sourceTree = "<group>"; };
-		B58BC7261DDBBE260079ED8B /* UserAgent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UserAgent.m; sourceTree = "<group>"; };
+		B58BC7251DDBBE260079ED8B /* TradeItUserAgentProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TradeItUserAgentProvider.h; sourceTree = "<group>"; };
+		B58BC7261DDBBE260079ED8B /* TradeItUserAgentProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TradeItUserAgentProvider.m; sourceTree = "<group>"; };
 		B59904AC1EFAAA050044E1DE /* TradeItYahooPreviewOrderWarningTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItYahooPreviewOrderWarningTableViewCell.swift; sourceTree = "<group>"; };
 		B59904AF1EFAAAD80044E1DE /* TradeItYahooPreviewOrderAcknowledgementTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItYahooPreviewOrderAcknowledgementTableViewCell.swift; sourceTree = "<group>"; };
 		B59F0CC51EA69D3E00C0F56F /* TradeItSubtitleWithDetailsCellTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TradeItSubtitleWithDetailsCellTableViewCell.swift; sourceTree = "<group>"; };
@@ -1450,8 +1450,8 @@
 				75BAAB391DB7EF2F00E5435C /* TradeItKeychain.h */,
 				75BAAB3A1DB7EF2F00E5435C /* TradeItKeychain.m */,
 				75BAAB6F1DB7EF2F00E5435C /* TradeItTypeDefs.h */,
-				B58BC7251DDBBE260079ED8B /* UserAgent.h */,
-				B58BC7261DDBBE260079ED8B /* UserAgent.m */,
+				B58BC7251DDBBE260079ED8B /* TradeItUserAgentProvider.h */,
+				B58BC7261DDBBE260079ED8B /* TradeItUserAgentProvider.m */,
 			);
 			path = TradeItIosEmsApi;
 			sourceTree = "<group>";
@@ -1698,7 +1698,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				75BAABB51DB7EF2F00E5435C /* TradeItGetPositionsResult.h in Headers */,
-				B58BC7271DDBBE260079ED8B /* UserAgent.h in Headers */,
+				B58BC7271DDBBE260079ED8B /* TradeItUserAgentProvider.h in Headers */,
 				75BAABB71DB7EF2F00E5435C /* TradeItIosEmsApiLib.h in Headers */,
 				7591A9111EFB09F0008EB943 /* TradeItFxOrderInfoResult.h in Headers */,
 				75AB474A1EFEEF5000A8BEC6 /* TradeItInstrumentOrderCapabilities.h in Headers */,
@@ -1778,7 +1778,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FC6E7A241DCD1F8B005225CC /* TradeItGetPositionsResult.h in Headers */,
-				B5719C171DDE616F000EE0BD /* UserAgent.h in Headers */,
+				B5719C171DDE616F000EE0BD /* TradeItUserAgentProvider.h in Headers */,
 				FC6E7A251DCD1F8B005225CC /* TradeItIosEmsApiLib.h in Headers */,
 				7591A9121EFB09F0008EB943 /* TradeItFxOrderInfoResult.h in Headers */,
 				75AB474B1EFEEF5000A8BEC6 /* TradeItInstrumentOrderCapabilities.h in Headers */,
@@ -2540,7 +2540,7 @@
 				75BAAAE51DB7EEB400E5435C /* TradeItTradePreviewViewController.swift in Sources */,
 				75F426171E1EEBE00054E15F /* TradeItThemeConfigurator.swift in Sources */,
 				75BAAAD21DB7EEB400E5435C /* TradeItPortfolioPositionPresenter.swift in Sources */,
-				B58BC7281DDBBE260079ED8B /* UserAgent.m in Sources */,
+				B58BC7281DDBBE260079ED8B /* TradeItUserAgentProvider.m in Sources */,
 				75BAAB8C1DB7EF2F00E5435C /* TradeItAccountOverviewRequest.m in Sources */,
 				75BAAAE01DB7EEB400E5435C /* TradeItSymbolSearchViewController.swift in Sources */,
 				75BAABE91DB7EF2F00E5435C /* TradeItSymbolLookupCompany.m in Sources */,
@@ -2714,7 +2714,7 @@
 				FC6E79F91DCD1F8B005225CC /* TradeItAccountManagementViewController.swift in Sources */,
 				FC6E79FA1DCD1F8B005225CC /* TradeItPreviewTradeResult.m in Sources */,
 				FC6E79FB1DCD1F8B005225CC /* TradeItWelcomeViewController.swift in Sources */,
-				B5719C181DDE6173000EE0BD /* UserAgent.m in Sources */,
+				B5719C181DDE6173000EE0BD /* TradeItUserAgentProvider.m in Sources */,
 				FC6E79FC1DCD1F8B005225CC /* TradeItViewController.swift in Sources */,
 				FC6E79FD1DCD1F8B005225CC /* TradeItTradeService.m in Sources */,
 				FC6E79FE1DCD1F8B005225CC /* TradeItPreviewTradeRequest.m in Sources */,

--- a/TradeItIosTicketSDK2/Info.plist
+++ b/TradeItIosTicketSDK2/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.16</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1.1.16</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/TradeItIosTicketSDK2/TradeItSDK.swift
+++ b/TradeItIosTicketSDK2/TradeItSDK.swift
@@ -160,7 +160,7 @@ import UIKit
     ) -> URLRequest? {
         var request = URLRequest(url: url)
         request.httpBody = jsonPostBody.data(using: .utf8)
-        request.httpMethod = "POST" // TODO: FIND APPLE CONSTANT
+        request.httpMethod = "POST"
         request.allHTTPHeaderFields = headers // TODO: Add Dictionary extension for merging dictionaries
 
         return request;

--- a/TradeItIosTicketSDK2Tests/Info.plist
+++ b/TradeItIosTicketSDK2Tests/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.16</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1.1.16</string>
 </dict>
 </plist>

--- a/deploy
+++ b/deploy
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+VERSION=$1
+
+xcrun agvtool what-version
+xcrun agvtool new-version -all $VERSION
+xcrun agvtool new-marketing-version $VERSION
+
+git add TradeItIosTicketSDK2.xcodeproj/project.pbxproj
+git add */Info.plist
+git commit -m "Version: $VERSION" -e -v
+
+carthage build --no-skip-current --platform iOS
+
+git tag $VERSION
+git push origin $VERSION
+
+pod repo push tradingticket *.podspec --verbose --allow-warnings


### PR DESCRIPTION
example current userAgent on simulator:

ExampleApp/1 CFNetwork/808.0.2 Darwin/15.6.0

New modified user agent:
ExampleApp/1.0/iOS 10.0 (iMac17,1) / TradeItIosTicketSDK2/1.0

We just need not to forget to update the version number  when we release a new version