### PR TITLE
[#134610027] fixes when launching portfolio with selected account

### DIFF
--- a/TradeItIosTicketSDK2/TradeItLinkedBrokerCache.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBrokerCache.swift
@@ -1,14 +1,13 @@
 class TradeItLinkedBrokerCache {
     typealias UserId = String
-    typealias AccountNumber = String
     typealias SerializedLinkedBroker = [String: Any]
     typealias SerializedLinkedBrokers = [UserId: SerializedLinkedBroker]
     typealias SerializedLinkedBrokerAccount = [String: String]
-    typealias SerializedLinkedBrokerAccounts = [AccountNumber: SerializedLinkedBrokerAccount]
 
     private let ACCOUNTS_KEY = "ACCOUNTS"
     private let ACCOUNTS_LAST_UPDATED_KEY = "ACCOUNTS_LAST_UPDATED"
     private let ACCOUNT_NAME_KEY = "ACCOUNT_NAME"
+    private let ACCOUNT_NUMBER_KEY = "ACCOUNT_NUMBER"
     private let LINKED_BROKER_CACHE_KEY = "LINKED_BROKER_CACHE"
 
     var defaults = UserDefaults(suiteName: "it.trade")!
@@ -31,7 +30,7 @@ class TradeItLinkedBrokerCache {
             , let serializedLinkedBroker = linkedBrokerCache[userId] as SerializedLinkedBroker?
             else { return }
 
-        if let serializedAccounts = serializedLinkedBroker[ACCOUNTS_KEY] as? SerializedLinkedBrokerAccounts {
+        if let serializedAccounts = serializedLinkedBroker[ACCOUNTS_KEY] as? [SerializedLinkedBrokerAccount] {
             let accounts = deserialize(serializedAccounts: serializedAccounts,
                                        forLinkedBroker: linkedBroker)
 
@@ -64,29 +63,30 @@ class TradeItLinkedBrokerCache {
         return serializedLinkedBroker
     }
 
-    private func deserialize(serializedAccounts: SerializedLinkedBrokerAccounts,
+    private func deserialize(serializedAccounts: [SerializedLinkedBrokerAccount],
                              forLinkedBroker linkedBroker: TradeItLinkedBroker) -> [TradeItLinkedBrokerAccount] {
-        return serializedAccounts.map { accountNumber, serializedAccount in
+        
+        
+        return serializedAccounts.map { serializedAccount in
             return TradeItLinkedBrokerAccount(linkedBroker: linkedBroker,
-                accountName: serializedAccount[ACCOUNT_NAME_KEY] ?? "",
-                accountNumber: accountNumber,
-                balance: nil,
-                fxBalance: nil,
-                positions: [])
+                                              accountName: serializedAccount[ACCOUNT_NAME_KEY] ?? "",
+                                              accountNumber: serializedAccount[ACCOUNT_NUMBER_KEY] ?? "",
+                                              balance: nil,
+                                              fxBalance: nil,
+                                              positions: [])
         }
     }
 
-    private func serialize(accounts: [TradeItLinkedBrokerAccount]) -> SerializedLinkedBrokerAccounts {
-        var serializedAccounts = SerializedLinkedBrokerAccounts()
-
+    private func serialize(accounts: [TradeItLinkedBrokerAccount]) -> [SerializedLinkedBrokerAccount] {
+        var serializeAccountsList: [SerializedLinkedBrokerAccount] = []
         for account in accounts {
             var serializedAccount = SerializedLinkedBrokerAccount()
-
             serializedAccount[ACCOUNT_NAME_KEY] = account.accountName
-
-            serializedAccounts[account.accountNumber] = serializedAccount
+            serializedAccount[ACCOUNT_NUMBER_KEY] = account.accountNumber
+            serializeAccountsList.append(serializedAccount)
         }
-
-        return serializedAccounts
+        
+        return serializeAccountsList
     }
+
 }

--- a/TradeItIosTicketSDK2/TradeItPortfolioAccountsTableViewManager.swift
+++ b/TradeItIosTicketSDK2/TradeItPortfolioAccountsTableViewManager.swift
@@ -34,7 +34,7 @@ class TradeItPortfolioAccountsTableViewManager: NSObject, UITableViewDelegate, U
 
         if accounts.count > 0 {
             let selectedAccount = selectedAccount ?? self.accounts[0]
-            let selectedAccountIndex = self.accounts.index(of: selectedAccount) ?? 0
+            let selectedAccountIndex = self.accounts.index(where: {$0.accountNumber == selectedAccount.accountNumber && $0.brokerName == selectedAccount.brokerName}) ?? 0
             let selectedIndexPath = IndexPath(row: selectedAccountIndex, section: 0)
             self.accountsTable?.selectRow(at: selectedIndexPath, animated: true, scrollPosition: .top)
             self.delegate?.linkedBrokerAccountWasSelected(selectedAccount: selectedAccount)

--- a/TradeItIosTicketSDK2Tests/TradeItLinkedBrokerCacheSpec.swift
+++ b/TradeItIosTicketSDK2Tests/TradeItLinkedBrokerCacheSpec.swift
@@ -103,19 +103,22 @@ class TradeItLinkedBrokerCacheSpec: QuickSpec {
                         let cachedDate1 = serializedBroker["ACCOUNTS_LAST_UPDATED"]! as! Date
                         expect(cachedDate1.timeIntervalSince1970).to(equal(date1.timeIntervalSince1970))
 
-                        let accounts = serializedBroker["ACCOUNTS"]! as! TradeItLinkedBrokerCache.SerializedLinkedBrokerAccounts
+                        let accounts = serializedBroker["ACCOUNTS"]! as! [TradeItLinkedBrokerCache.SerializedLinkedBrokerAccount]
 
                         expect(accounts.count).to(equal(2))
 
-                        let serializedAccount1 = accounts["My Special Account Number 1"]!
+                        let serializedAccount1 = accounts[0]
 
-                        expect(serializedAccount1.keys.count).to(equal(1))
+                        expect(serializedAccount1.keys.count).to(equal(2))
                         expect(serializedAccount1["ACCOUNT_NAME"]!).to(equal("My Special Account Name 1"))
+                        expect(serializedAccount1["ACCOUNT_NUMBER"]!).to(equal("My Special Account Number 1"))
 
-                        let serializedAccount2 = accounts["My Special Account Number 2"]!
 
-                        expect(serializedAccount2.keys.count).to(equal(1))
+                        let serializedAccount2 = accounts[1]
+
+                        expect(serializedAccount2.keys.count).to(equal(2))
                         expect(serializedAccount2["ACCOUNT_NAME"]!).to(equal("My Special Account Name 2"))
+                        expect(serializedAccount2["ACCOUNT_NUMBER"]!).to(equal("My Special Account Number 2"))
                     }
 
                     describe ("adding a subsequent linked broker") {
@@ -142,18 +145,20 @@ class TradeItLinkedBrokerCacheSpec: QuickSpec {
                             let cachedDate2 = serializedBroker2["ACCOUNTS_LAST_UPDATED"]! as! Date
                             expect(cachedDate2.compare(date2)).to(equal(ComparisonResult.orderedSame))
 
-                            let accounts1 = serializedBroker1["ACCOUNTS"] as! TradeItLinkedBrokerCache.SerializedLinkedBrokerAccounts
+                            let accounts1 = serializedBroker1["ACCOUNTS"] as! [TradeItLinkedBrokerCache.SerializedLinkedBrokerAccount]
 
                             expect(accounts1.count).to(equal(2))
 
-                            let accounts2 = serializedBroker2["ACCOUNTS"] as! TradeItLinkedBrokerCache.SerializedLinkedBrokerAccounts
+                            let accounts2 = serializedBroker2["ACCOUNTS"] as! [TradeItLinkedBrokerCache.SerializedLinkedBrokerAccount]
 
                             expect(accounts2.count).to(equal(1))
 
-                            let serializedAccount3 = accounts2["My Special Account Number 3"]!
+                            let serializedAccount3 = accounts2[0]
 
-                            expect(serializedAccount3.keys.count).to(equal(1))
+                            expect(serializedAccount3.keys.count).to(equal(2))
                             expect(serializedAccount3["ACCOUNT_NAME"]!).to(equal("My Special Account Name 3"))
+                            expect(serializedAccount3["ACCOUNT_NUMBER"]!).to(equal("My Special Account Number 3"))
+                            
                         }
                     }
                 }
@@ -195,14 +200,16 @@ class TradeItLinkedBrokerCacheSpec: QuickSpec {
                         let cachedDate1 = serializedBroker1["ACCOUNTS_LAST_UPDATED"]! as! Date
                         expect(cachedDate1.timeIntervalSince1970).to(equal(newDate.timeIntervalSince1970))
 
-                        let accounts1 = serializedBroker1["ACCOUNTS"] as! TradeItLinkedBrokerCache.SerializedLinkedBrokerAccounts
+                        let accounts1 = serializedBroker1["ACCOUNTS"] as! [TradeItLinkedBrokerCache.SerializedLinkedBrokerAccount]
 
                         expect(accounts1.count).to(equal(1))
 
-                        let newSerializedAccount = accounts1["My New Account Number"]!
+                        let newSerializedAccount = accounts1[0]
 
-                        expect(newSerializedAccount.keys.count).to(equal(1))
+                        expect(newSerializedAccount.keys.count).to(equal(2))
                         expect(newSerializedAccount["ACCOUNT_NAME"]!).to(equal("My New Account Name"))
+                        expect(newSerializedAccount["ACCOUNT_NUMBER"]!).to(equal("My New Account Number"))
+                        
 
                         let serializedBroker2 = serializedBrokers["My Special User ID 2"]! as TradeItLinkedBrokerCache.SerializedLinkedBroker
 
@@ -211,14 +218,16 @@ class TradeItLinkedBrokerCacheSpec: QuickSpec {
                         let cachedDate2 = serializedBroker2["ACCOUNTS_LAST_UPDATED"]! as! Date
                         expect(cachedDate2.timeIntervalSince1970).to(equal(date2.timeIntervalSince1970))
 
-                        let accounts2 = serializedBroker2["ACCOUNTS"] as! TradeItLinkedBrokerCache.SerializedLinkedBrokerAccounts
+                        let accounts2 = serializedBroker2["ACCOUNTS"] as! [TradeItLinkedBrokerCache.SerializedLinkedBrokerAccount]
 
                         expect(accounts2.count).to(equal(1))
 
-                        let serializedAccount3 = accounts2["My Special Account Number 3"]!
+                        let serializedAccount3 = accounts2[0]
 
-                        expect(serializedAccount3.keys.count).to(equal(1))
+                        expect(serializedAccount3.keys.count).to(equal(2))
                         expect(serializedAccount3["ACCOUNT_NAME"]!).to(equal("My Special Account Name 3"))
+                        expect(serializedAccount3["ACCOUNT_NUMBER"]!).to(equal("My Special Account Number 3"))
+                        
                     }
                 }
             }
@@ -282,19 +291,21 @@ class TradeItLinkedBrokerCacheSpec: QuickSpec {
                         let cachedDate1 = serializedBroker1["ACCOUNTS_LAST_UPDATED"]! as! Date
                         expect(cachedDate1.timeIntervalSince1970).to(equal(date1.timeIntervalSince1970))
 
-                        let serializedAccounts1 = serializedBroker1["ACCOUNTS"]! as! TradeItLinkedBrokerCache.SerializedLinkedBrokerAccounts
+                        let serializedAccounts1 = serializedBroker1["ACCOUNTS"]! as! [TradeItLinkedBrokerCache.SerializedLinkedBrokerAccount]
 
                         expect(serializedAccounts1.count).to(equal(2))
 
-                        let serializedAccount1 = serializedAccounts1["My Special Account Number 1"]!
+                        let serializedAccount1 = serializedAccounts1[0]
 
-                        expect(serializedAccount1.keys.count).to(equal(1))
+                        expect(serializedAccount1.keys.count).to(equal(2))
                         expect(serializedAccount1["ACCOUNT_NAME"]!).to(equal("My Special Account Name 1"))
+                        expect(serializedAccount1["ACCOUNT_NUMBER"]!).to(equal("My Special Account Number 1"))
 
-                        let serializedAccount2 = serializedAccounts1["My Special Account Number 2"]!
+                        let serializedAccount2 = serializedAccounts1[1]
 
-                        expect(serializedAccount2.keys.count).to(equal(1))
+                        expect(serializedAccount2.keys.count).to(equal(2))
                         expect(serializedAccount2["ACCOUNT_NAME"]!).to(equal("My Special Account Name 2"))
+                        expect(serializedAccount2["ACCOUNT_NUMBER"]!).to(equal("My Special Account Number 2"))
 
                         let serializedBroker2 = serializedBrokers["My Special User ID 2"]! as TradeItLinkedBrokerCache.SerializedLinkedBroker
 
@@ -303,14 +314,16 @@ class TradeItLinkedBrokerCacheSpec: QuickSpec {
                         let cachedDate2 = serializedBroker2["ACCOUNTS_LAST_UPDATED"]! as! Date
                         expect(cachedDate2.timeIntervalSince1970).to(equal(date2.timeIntervalSince1970))
 
-                        let serializedAccounts2 = serializedBroker2["ACCOUNTS"] as! TradeItLinkedBrokerCache.SerializedLinkedBrokerAccounts
+                        let serializedAccounts2 = serializedBroker2["ACCOUNTS"] as! [TradeItLinkedBrokerCache.SerializedLinkedBrokerAccount]
 
                         expect(serializedAccounts2.count).to(equal(1))
 
-                        let serializedAccount3 = serializedAccounts2["My Special Account Number 3"]!
+                        let serializedAccount3 = serializedAccounts2[0]
 
-                        expect(serializedAccount3.keys.count).to(equal(1))
+                        expect(serializedAccount3.keys.count).to(equal(2))
                         expect(serializedAccount3["ACCOUNT_NAME"]!).to(equal("My Special Account Name 3"))
+                        expect(serializedAccount3["ACCOUNT_NUMBER"]!).to(equal("My Special Account Number 3"))
+                        
                     }
                 }
 
@@ -369,19 +382,21 @@ class TradeItLinkedBrokerCacheSpec: QuickSpec {
                         let cachedDate1 = serializedBroker1["ACCOUNTS_LAST_UPDATED"]! as! Date
                         expect(cachedDate1.timeIntervalSince1970).to(equal(date1.timeIntervalSince1970))
 
-                        let serializedAccounts1 = serializedBroker1["ACCOUNTS"]! as! TradeItLinkedBrokerCache.SerializedLinkedBrokerAccounts
+                        let serializedAccounts1 = serializedBroker1["ACCOUNTS"]! as! [TradeItLinkedBrokerCache.SerializedLinkedBrokerAccount]
 
                         expect(serializedAccounts1.count).to(equal(2))
 
-                        let serializedAccount1 = serializedAccounts1["My Special Account Number 1"]!
+                        let serializedAccount1 = serializedAccounts1[0]
 
-                        expect(serializedAccount1.keys.count).to(equal(1))
+                        expect(serializedAccount1.keys.count).to(equal(2))
                         expect(serializedAccount1["ACCOUNT_NAME"]!).to(equal("My Special Account Name 1"))
+                        expect(serializedAccount1["ACCOUNT_NUMBER"]!).to(equal("My Special Account Number 1"))
 
-                        let serializedAccount2 = serializedAccounts1["My Special Account Number 2"]!
+                        let serializedAccount2 = serializedAccounts1[1]
 
-                        expect(serializedAccount2.keys.count).to(equal(1))
+                        expect(serializedAccount2.keys.count).to(equal(2))
                         expect(serializedAccount2["ACCOUNT_NAME"]!).to(equal("My Special Account Name 2"))
+                        expect(serializedAccount2["ACCOUNT_NUMBER"]!).to(equal("My Special Account Number 2"))
 
                         let serializedBroker2 = serializedBrokers["My Special User ID 2"]! as TradeItLinkedBrokerCache.SerializedLinkedBroker
 
@@ -390,14 +405,15 @@ class TradeItLinkedBrokerCacheSpec: QuickSpec {
                         let cachedDate2 = serializedBroker2["ACCOUNTS_LAST_UPDATED"]! as! Date
                         expect(cachedDate2.timeIntervalSince1970).to(equal(date2.timeIntervalSince1970))
 
-                        let serializedAccounts2 = serializedBroker2["ACCOUNTS"] as! TradeItLinkedBrokerCache.SerializedLinkedBrokerAccounts
+                        let serializedAccounts2 = serializedBroker2["ACCOUNTS"] as! [TradeItLinkedBrokerCache.SerializedLinkedBrokerAccount]
 
                         expect(serializedAccounts2.count).to(equal(1))
 
-                        let serializedAccount3 = serializedAccounts2["My Special Account Number 3"]!
+                        let serializedAccount3 = serializedAccounts2[0]
                         
-                        expect(serializedAccount3.keys.count).to(equal(1))
+                        expect(serializedAccount3.keys.count).to(equal(2))
                         expect(serializedAccount3["ACCOUNT_NAME"]!).to(equal("My Special Account Name 3"))
+                        expect(serializedAccount3["ACCOUNT_NUMBER"]!).to(equal("My Special Account Number 3"))
                     }
                 }
             }


### PR DESCRIPTION
There were 2 issues:
- We used Dictionary to store the data in userDefaults and Dictionary doesn't guaranty the order, so the accounts were stored in reverse order.
- In the portfolioviewcontroller we checked if the selected account (loaded from the cache) was in the account table (table of new TradeItLinkedBrokerAccount because we create new object when we authenticate), so the reference were not equal.