### PR TITLE
Fix unowned LinkedBroker reference

### DIFF
--- a/ExampleApp/ExampleViewController.swift
+++ b/ExampleApp/ExampleViewController.swift
@@ -139,6 +139,19 @@ class ExampleViewController: UIViewController, UITableViewDataSource, UITableVie
                 ]
             ),
             Section(
+                label: "Debugging",
+                actions: [
+                    Action(
+                        label: "deleteLinkedBrokers",
+                        action: deleteLinkedBrokers
+                    ),
+                    Action(
+                        label: "test",
+                        action: test
+                    )
+                ]
+            ),
+            Section(
                 label: "Themes",
                 actions: [
                     Action(

--- a/TradeItIosTicketSDK2/TradeItLinkedBrokerAccount.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBrokerAccount.swift
@@ -1,6 +1,6 @@
 @objc public class TradeItLinkedBrokerAccount: NSObject {
-    public var brokerName: String {
-        return self.linkedBroker.brokerName
+    public var brokerName: String? {
+        return self.linkedBroker?.brokerName
     }
 
     public var accountName = ""
@@ -8,7 +8,7 @@
     public var balance: TradeItAccountOverview?
     public var fxBalance: TradeItFxAccountOverview?
     public var positions: [TradeItPortfolioPosition] = []
-    unowned var linkedBroker: TradeItLinkedBroker
+    weak var linkedBroker: TradeItLinkedBroker?
     var tradeItBalanceService: TradeItBalanceService
     var tradeItPositionService: TradeItPositionService
     var tradeService: TradeItTradeService
@@ -41,9 +41,9 @@
         self.fxBalance = fxBalance
         self.positions = positions
         self._enabled = isEnabled
-        self.tradeItBalanceService = TradeItBalanceService(session: self.linkedBroker.session)
-        self.tradeItPositionService = TradeItPositionService(session: self.linkedBroker.session)
-        self.tradeService = TradeItTradeService(session: self.linkedBroker.session)
+        self.tradeItBalanceService = TradeItBalanceService(session: linkedBroker.session)
+        self.tradeItPositionService = TradeItPositionService(session: linkedBroker.session)
+        self.tradeService = TradeItTradeService(session: linkedBroker.session)
     }
 
     public func getAccountOverview(onSuccess: @escaping (TradeItAccountOverview?) -> Void, onFailure: @escaping (TradeItErrorResult) -> Void) {
@@ -53,10 +53,10 @@
             case let accountOverviewResult as TradeItAccountOverviewResult:
                 self.balance = accountOverviewResult.accountOverview
                 self.fxBalance = accountOverviewResult.fxAccountOverview
-                self.linkedBroker.error = nil
+                self.linkedBroker?.error = nil
                 onSuccess(accountOverviewResult.accountOverview)
             case let errorResult as TradeItErrorResult:
-                self.linkedBroker.error = errorResult
+                self.linkedBroker?.error = errorResult
                 onFailure(errorResult)
             default:
                 onFailure(TradeItErrorResult(title: "Failed to retrieve account balances"))
@@ -83,7 +83,7 @@
                 self.positions = portfolioEquityPositions + portfolioFxPositions
                 onSuccess(self.positions)
             case let errorResult as TradeItErrorResult:
-                self.linkedBroker.error = errorResult
+                self.linkedBroker?.error = errorResult
                 onFailure(errorResult)
             default:
                 onFailure(TradeItErrorResult(title: "Failed to retrieve account positions"))

--- a/TradeItIosTicketSDK2/TradeItLinkedBrokerCache.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBrokerCache.swift
@@ -20,8 +20,8 @@ class TradeItLinkedBrokerCache {
         }
     }
 
-    func cache(linkedBroker: TradeItLinkedBroker) {
-        guard let userId = linkedBroker.linkedLogin.userId else { return }
+    func cache(linkedBroker: TradeItLinkedBroker?) {
+        guard let linkedBroker = linkedBroker, let userId = linkedBroker.linkedLogin.userId else { return }
 
         var linkedBrokerCache = userDefaults.dictionary(forKey: LINKED_BROKER_CACHE_KEY) as? SerializedLinkedBrokers ?? SerializedLinkedBrokers()
 

--- a/TradeItIosTicketSDK2/TradeItOrder.swift
+++ b/TradeItIosTicketSDK2/TradeItOrder.swift
@@ -81,7 +81,7 @@ public typealias TradeItPlaceOrderHandlers = (_ onSuccess: @escaping (TradeItPla
                           self.generatePlaceOrderCallback(tradeService: linkedBrokerAccount.tradeService,
                                                           previewOrderResult: previewOrderResult))
             case let errorResult as TradeItErrorResult:
-                linkedBrokerAccount.linkedBroker.error = errorResult
+                linkedBrokerAccount.linkedBroker?.error = errorResult
                 onFailure(errorResult)
             default: onFailure(TradeItErrorResult(title: "Preview failed", message: "There was a problem previewing your order. Please try again."))
             }

--- a/TradeItIosTicketSDK2/TradeItPortfolioPosition.swift
+++ b/TradeItIosTicketSDK2/TradeItPortfolioPosition.swift
@@ -24,8 +24,7 @@
             }, onFailure: { _ in
                 onFinished()
             })
-        } else if let fxPosition = self.fxPosition, let fxSymbol = fxPosition.symbol {
-            let broker = self.linkedBrokerAccount.brokerName
+        } else if let fxPosition = self.fxPosition, let fxSymbol = fxPosition.symbol, let broker = self.linkedBrokerAccount.brokerName {
             TradeItSDK.marketDataService.getFxQuote(symbol: fxSymbol, broker: broker, onSuccess: { quote in
                 self.quote = quote
                 onFinished()

--- a/TradeItIosTicketSDK2/TradeItTradePreviewViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItTradePreviewViewController.swift
@@ -68,8 +68,15 @@ class TradeItTradePreviewViewController: TradeItViewController, UITableViewDeleg
             self.delegate?.orderSuccessfullyPlaced(onTradePreviewViewController: self, withPlaceOrderResult: result)
         }, { error in
             activityView.hide(animated: true)
+            guard let linkedBroker = self.linkedBrokerAccount.linkedBroker else {
+                return self.alertManager.showError(
+                    error,
+                    onViewController: self
+                )
+            }
+
             self.alertManager.showRelinkError(error,
-                withLinkedBroker: self.linkedBrokerAccount.linkedBroker,
+                withLinkedBroker: linkedBroker,
                 onViewController: self,
                 onFinished: {} // TODO: Retry?
             )


### PR DESCRIPTION
Potential crash if a user unlinks a broker, and the garbage collector cleans it up before the user goes back to the trading screen.