### PR TITLE
[#139297907] fix invalid api key issue

### DIFF
--- a/TradeItIosEmsApi/TradeItSession.m
+++ b/TradeItIosEmsApi/TradeItSession.m
@@ -60,15 +60,16 @@
 
 - (TradeItResult *)parseAuthResponse:(TradeItResult *)authenticationResult
                         jsonResponse:(NSMutableString *)jsonResponse {
-    self.token = [authenticationResult token];
     NSString *status = authenticationResult.status;
 
     TradeItResult *resultToReturn;
 
     if ([status isEqual:@"SUCCESS"]) {
+        self.token = [authenticationResult token];
         resultToReturn = [TradeItJsonConverter buildResult:[TradeItAuthenticationResult alloc] jsonString:jsonResponse];
 
     } else if ([status isEqualToString:@"INFORMATION_NEEDED"]) {
+        self.token = [authenticationResult token];
         resultToReturn = [TradeItJsonConverter buildResult:[TradeItSecurityQuestionResult alloc] jsonString:jsonResponse];
         
     } else if ([status isEqualToString:@"ERROR"]) {

--- a/TradeItIosTicketSDK2/TradeItLinkedBrokerManager.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBrokerManager.swift
@@ -325,6 +325,8 @@ import PromiseKit
 
     private func loadLinkedBrokerFromLinkedLogin(_ linkedLogin: TradeItLinkedLogin) -> TradeItLinkedBroker {
         let tradeItSession = sessionProvider.provide(connector: self.connector)
+        //provides a default token, so if the user doesn't authenticate before an other call, it will pass an expired token in order to get the session expired error
+        tradeItSession?.token = "dd61aa94fa094e6ab54fa4b31853bbd4"
         return TradeItLinkedBroker(session: tradeItSession!, linkedLogin: linkedLogin)
     }
 


### PR DESCRIPTION
Linked to https://github.com/tradingticket/server/pull/948
As the session token is required, providing a default expired token, so if the user doesn't authenticate after launching from cache, he will get a session token expired.
Also, setting the session token only when the authenticate call is successful, otherwise it will reset it to null.