### PR TITLE
OAuth uses SFSafariViewController instead of launching Safari

### DIFF
--- a/TradeItIosTicketSDK2/TradeItLauncher.swift
+++ b/TradeItIosTicketSDK2/TradeItLauncher.swift
@@ -19,22 +19,29 @@ protocol OAuthCompletionListener {
     override internal init() {}
 
     public func handleOAuthCallback(
-        onViewController viewController: UIViewController,
+        onViewController safariViewController: UIViewController,
         oAuthCallbackUrl: URL
     ) {
         print("=====> handleOAuthCallback: \(oAuthCallbackUrl.absoluteString)")
 
         let oAuthCallbackUrlParser = TradeItOAuthCallbackUrlParser(oAuthCallbackUrl: oAuthCallbackUrl)
 
-        guard let originalViewController = safariViewController.presentingViewController?.presentingViewController else {
+        var parentViewController = safariViewController.presentingViewController
+
+        // If this is a new link and not a relink then there is a SelectBrokerVC that also needs to be dismissed.
+        if parentViewController?.childViewControllers.first is TradeItSelectBrokerViewController {
+            parentViewController = parentViewController?.presentingViewController
+        }
+
+        guard let originalViewController = parentViewController else {
             preconditionFailure("View hierarchy in unknown state.")
         }
+
 
         originalViewController.dismiss(animated: true, completion: {
             self.oAuthCompletionUIFlow.presentOAuthCompletionFlow(
                 fromViewController: originalViewController,
-                oAuthCallbackUrlParser: oAuthCallbackUrlParser,
-                onSuccessfulLink: onSuccessfulLink
+                oAuthCallbackUrlParser: oAuthCallbackUrlParser
             )
         })
     }

--- a/TradeItIosTicketSDK2/TradeItLauncher.swift
+++ b/TradeItIosTicketSDK2/TradeItLauncher.swift
@@ -26,10 +26,17 @@ protocol OAuthCompletionListener {
 
         let oAuthCallbackUrlParser = TradeItOAuthCallbackUrlParser(oAuthCallbackUrl: oAuthCallbackUrl)
 
-        self.oAuthCompletionUIFlow.presentOAuthCompletionFlow(
-            fromViewController: viewController,
-            oAuthCallbackUrlParser: oAuthCallbackUrlParser
-        )
+        guard let originalViewController = safariViewController.presentingViewController?.presentingViewController else {
+            preconditionFailure("View hierarchy in unknown state.")
+        }
+
+        originalViewController.dismiss(animated: true, completion: {
+            self.oAuthCompletionUIFlow.presentOAuthCompletionFlow(
+                fromViewController: originalViewController,
+                oAuthCallbackUrlParser: oAuthCallbackUrlParser,
+                onSuccessfulLink: onSuccessfulLink
+            )
+        })
     }
 
     public func launchPortfolio(fromViewController viewController: UIViewController) {
@@ -45,7 +52,7 @@ protocol OAuthCompletionListener {
 
                 oAuthCallbackUrl = urlComponents.url ?? oAuthCallbackUrl
             }
-            
+
             self.linkBrokerUIFlow.presentLinkBrokerFlow(
                 fromViewController: viewController,
                 showWelcomeScreen: true,

--- a/TradeItIosTicketSDK2/TradeItLinkBrokerUIFlow.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkBrokerUIFlow.swift
@@ -1,5 +1,6 @@
 import UIKit
 import MBProgressHUD
+import SafariServices
 
 class TradeItLinkBrokerUIFlow: NSObject,
                                TradeItWelcomeViewControllerDelegate {
@@ -52,7 +53,8 @@ class TradeItLinkBrokerUIFlow: NSObject,
             oAuthCallbackUrl: oAuthCallbackUrl,
             onSuccess: { url in
                 activityView.hide(animated: true)
-                UIApplication.shared.openURL(url)
+                let safariViewController = SFSafariViewController(url: url)
+                viewController.present(safariViewController, animated: true, completion: nil)
             },
             onFailure: { errorResult in
                 TradeItAlertManager().showError(errorResult, onViewController: viewController)

--- a/TradeItIosTicketSDK2/TradeItSelectBrokerViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItSelectBrokerViewController.swift
@@ -78,7 +78,7 @@ class TradeItSelectBrokerViewController: TradeItViewController, UITableViewDeleg
             onSuccess: { url in
                 self.activityView?.hide(animated: true)
                 let safariViewController = SFSafariViewController(url: url)
-                self.navigationController?.present(safariViewController, animated: true, completion: nil)
+                self.present(safariViewController, animated: true, completion: nil)
             },
             onFailure: { errorResult in
                 self.alertManager.showError(errorResult,

--- a/TradeItIosTicketSDK2/TradeItSelectBrokerViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItSelectBrokerViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import MBProgressHUD
+import SafariServices
 
 class TradeItSelectBrokerViewController: TradeItViewController, UITableViewDelegate, UITableViewDataSource {
     @IBOutlet weak var brokerTable: UITableView!
@@ -76,8 +77,8 @@ class TradeItSelectBrokerViewController: TradeItViewController, UITableViewDeleg
             oAuthCallbackUrl: self.oAuthCallbackUrl!,
             onSuccess: { url in
                 self.activityView?.hide(animated: true)
-                UIApplication.shared.openURL(url)
-                self.dismiss(animated: true)
+                let safariViewController = SFSafariViewController(url: url)
+                self.navigationController?.present(safariViewController, animated: true, completion: nil)
             },
             onFailure: { errorResult in
                 self.alertManager.showError(errorResult,


### PR DESCRIPTION
Pros: Smoother UX
Cons: ~10mb higher memory footprint for the SDK even if the screen isn't used