### PR TITLE
Change TradeItAlertManager constructor to be public

### DIFF
--- a/TradeItIosTicketSDK2/TradeItAlertManager.swift
+++ b/TradeItIosTicketSDK2/TradeItAlertManager.swift
@@ -10,7 +10,7 @@ import UIKit
         super.init()
     }
 
-    override init() {
+    public override init() {
         super.init()
     }
 


### PR DESCRIPTION
TradeItAlertManager constructor needs to be public to allow using it (for example, when calling `authenticateIfNeeded`) in apps installing the SDK via Carthage