### PR TITLE
support adding custom params when getting OAuth token

### DIFF
--- a/TradeItIosEmsApi/TradeItConnector.h
+++ b/TradeItIosEmsApi/TradeItConnector.h
@@ -139,6 +139,7 @@
                                       completionBlock:(void (^ _Nonnull)(TradeItResult * _Nullable))completionBlock;
 
 - (void)getOAuthAccessTokenWithOAuthVerifier:(NSString * _Nullable)oAuthVerifier
+                                customParams:(NSDictionary<NSString *, NSString *> *)params
                              completionBlock:(void (^ _Nullable)(TradeItResult * _Nullable))completionBlock;
 
 @end

--- a/TradeItIosTicketSDK2/TradeItLinkedBrokerManager.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBrokerManager.swift
@@ -97,10 +97,11 @@ import PromiseKit
 
     public func completeOAuth(
         withOAuthVerifier oAuthVerifier: String,
+        customParams: [String: String]?,
         onSuccess: @escaping (_ linkedBroker: TradeItLinkedBroker) -> Void,
         onFailure: @escaping (TradeItErrorResult) -> Void
     ) -> Void {
-        self.connector.getOAuthAccessToken(withOAuthVerifier: oAuthVerifier) { tradeItResult in
+        self.connector.getOAuthAccessToken(withOAuthVerifier: oAuthVerifier, customParams: customParams) { tradeItResult in
             switch tradeItResult {
             case let errorResult as TradeItErrorResult:
                 onFailure(errorResult)

--- a/TradeItIosTicketSDK2/TradeItOAuthCompletionViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItOAuthCompletionViewController.swift
@@ -38,6 +38,7 @@ class TradeItOAuthCompletionViewController: TradeItViewController {
 
         TradeItSDK.linkedBrokerManager.completeOAuth(
             withOAuthVerifier: oAuthVerifier,
+            customParams: nil,
             onSuccess: { linkedBroker in
                 self.linkedBroker = linkedBroker
                 linkedBroker.authenticateIfNeeded(

--- a/TradeItIosTicketSDK2/TradeItYahooOAuthCompletionViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItYahooOAuthCompletionViewController.swift
@@ -37,6 +37,7 @@ import UIKit
 
         TradeItSDK.linkedBrokerManager.completeOAuth(
             withOAuthVerifier: self.oAuthCallbackUrlParser.oAuthCallbackUrl.absoluteString, // Y! Finance backend will parse out OAuthVerifier
+            customParams: nil,
             onSuccess: { linkedBroker in
                 self.linkedBroker = linkedBroker
                 linkedBroker.authenticateIfNeeded(


### PR DESCRIPTION
Hey folk...

We need to add a custom param to the request for an oauth access token, I added this capability, please see if it is to your liking.

I know independently you're working on allowing us to create/sign your URLRequests, but that's not ideal for this case as the extra param is specific to the call launched in response to the deep link.

This may need tweaking for the new solution as it relies on mutating the URLRequest, but hopefully you get the jist of what we'd like, i.e. passing in the extra params specifically for getOAuthAccessToken.

--Iain.