### PR TITLE
Fix Symbol Search Screen keyboard hiding content

### DIFF
--- a/TradeItIosTicketSDK2/TradeItSymbolSearchViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItSymbolSearchViewController.swift
@@ -15,7 +15,7 @@ class TradeItSymbolSearchViewController: TradeItViewController, UITableViewDeleg
 
         self.activityIndicator.hidesWhenStopped = true
         setupSearchTextField()
-        
+
         TradeItSDK.adService.populate?(
             adContainer: adContainer,
             rootViewController: self,
@@ -27,7 +27,7 @@ class TradeItSymbolSearchViewController: TradeItViewController, UITableViewDeleg
             trackPageViewAsPageType: false
         )
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         searchTextField.becomeFirstResponder()
@@ -45,7 +45,7 @@ class TradeItSymbolSearchViewController: TradeItViewController, UITableViewDeleg
         searchTextField.autocorrectionType = .no
         searchTextField.returnKeyType = .done
     }
-    
+
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         searchTextField.resignFirstResponder()
         return true
@@ -56,14 +56,14 @@ class TradeItSymbolSearchViewController: TradeItViewController, UITableViewDeleg
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let originalText: NSString = textField.text as NSString? ?? ""
         let resultText = originalText.replacingCharacters(in: range, with: string)
-        
+
         self.activityIndicator.startAnimating()
-        
+
         TradeItSDK.symbolService.symbolLookup(
             resultText,
             onSuccess: { results in
                 let inputText = textField.text
-                
+
                 if inputText == resultText {
                     self.activityIndicator.stopAnimating()
                     self.symbolSearchResults = results
@@ -85,7 +85,6 @@ class TradeItSymbolSearchViewController: TradeItViewController, UITableViewDeleg
 
         self.delegate?.symbolSearchViewController(self, didSelectSymbol: selectedSymbol)
     }
-
 
     // MARK: UITableViewDataSource
 

--- a/TradeItIosTicketSDK2/TradeItSymbolSearchViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItSymbolSearchViewController.swift
@@ -15,7 +15,7 @@ class TradeItSymbolSearchViewController: TradeItViewController, UITableViewDeleg
 
         self.activityIndicator.hidesWhenStopped = true
         setupSearchTextField()
-
+        
         TradeItSDK.adService.populate?(
             adContainer: adContainer,
             rootViewController: self,
@@ -27,7 +27,7 @@ class TradeItSymbolSearchViewController: TradeItViewController, UITableViewDeleg
             trackPageViewAsPageType: false
         )
     }
-
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         searchTextField.becomeFirstResponder()
@@ -42,8 +42,14 @@ class TradeItSymbolSearchViewController: TradeItViewController, UITableViewDeleg
         searchLabel.sizeToFit()
         searchTextField.leftView = searchLabel
         searchTextField.leftViewMode = .always
+        searchTextField.autocorrectionType = .no
+        searchTextField.returnKeyType = .done
     }
     
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        searchTextField.resignFirstResponder()
+        return true
+    }
 
     // MARK: UITextFieldDelegate
 


### PR DESCRIPTION
1. Added Done button at the bottom of the keyboard. Select will hide keyboard
2. I have also hided the auto-suggestion from the keyboard, reason being that auto-suggestion should have no impact on user experience during symbol search. If you agree that is the case, the auto-suggestion is just using up space of the screen, which is significant for iphone 5 screen size.

<img width="375" alt="screen shot 2017-07-21 at 11 33 25 am" src="https://user-images.githubusercontent.com/12431442/28470955-6fa93894-6e09-11e7-922b-db93e9447d71.png">
