### PR TITLE
Add Trading with singapore symbol to the example app for testing CIMB

### DIFF
--- a/ExampleApp/ExampleViewController.swift
+++ b/ExampleApp/ExampleViewController.swift
@@ -220,6 +220,20 @@ class ExampleViewController: UIViewController, UITableViewDataSource, UITableVie
                         }
                     ),
                     Action(
+                        label: "Trading with singapore symbol",
+                        action: {
+                            let order = TradeItOrder()
+                            // Any order fields that are set will pre-populate the ticket.
+                            order.symbol = "T39"
+                            order.quantity = 100
+                            order.action = .buy
+                            order.type = .limit
+                            order.limitPrice = 0.5
+                            order.expiration = .goodForDay
+                            TradeItSDK.launcher.launchTrading(fromViewController: self, withOrder: order)
+                        }
+                    ),
+                    Action(
                         label: "Manage Accounts",
                         action: {
                             TradeItSDK.launcher.launchAccountManagement(fromViewController: self.advancedViewController)


### PR DESCRIPTION
I added this to the example app in order to test more easily CIMB (because our symbol selection screen doesn't search for Singapore symbols).

If you think it is not mergeable, could you install this version on Nico's phone ? He needs to pass a trade and then test the security question when cancelling an order from the orders screen for CIMB.

Thanks
