### PR TITLE
Removes optional populate() method from AdService protocol

### DIFF
--- a/TradeItIosTicketSDK2/AdService.swift
+++ b/TradeItIosTicketSDK2/AdService.swift
@@ -5,14 +5,6 @@ import UIKit
         adContainer: UIView,
         rootViewController: UIViewController,
         pageType: TradeItAdPageType,
-        position: TradeItAdPosition
-    )
-
-    // Obj-C compatibility helper
-    @objc optional func populate(
-        adContainer: UIView,
-        rootViewController: UIViewController,
-        pageType: TradeItAdPageType,
         position: TradeItAdPosition,
         broker: String?,
         symbol: String?,

--- a/TradeItIosTicketSDK2/TradeItFxTradingTicketViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItFxTradingTicketViewController.swift
@@ -52,7 +52,7 @@ class TradeItFxTradingTicketViewController: TradeItViewController, UITableViewDa
 
         self.updateOrderCapabilities()
 
-        TradeItSDK.adService.populate?(
+        TradeItSDK.adService.populate(
             adContainer: adContainer,
             rootViewController: self,
             pageType: .trading,

--- a/TradeItIosTicketSDK2/TradeItOAuthCompletionViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItOAuthCompletionViewController.swift
@@ -42,7 +42,7 @@ class TradeItOAuthCompletionViewController: TradeItViewController {
                 self.linkedBroker = linkedBroker
                 linkedBroker.authenticateIfNeeded(
                     onSuccess: {
-                        TradeItSDK.adService.populate?(
+                        TradeItSDK.adService.populate(
                             adContainer: self.adContainer,
                             rootViewController: self,
                             pageType: .link,

--- a/TradeItIosTicketSDK2/TradeItPortfolioAccountDetailsViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItPortfolioAccountDetailsViewController.swift
@@ -26,7 +26,7 @@ class TradeItPortfolioAccountDetailsViewController: TradeItViewController, Trade
 
         self.tableViewManager.initiateRefresh()
 
-        TradeItSDK.adService.populate?(
+        TradeItSDK.adService.populate(
             adContainer: self.adContainer,
             rootViewController: self,
             pageType: .portfolio,

--- a/TradeItIosTicketSDK2/TradeItSelectionViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItSelectionViewController.swift
@@ -21,7 +21,7 @@ class TradeItSelectionViewController: TradeItViewController {
             }
         )
 
-        TradeItSDK.adService.populate?(
+        TradeItSDK.adService.populate(
             adContainer: adContainer,
             rootViewController: self,
             pageType: .trading,

--- a/TradeItIosTicketSDK2/TradeItTradePreviewViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItTradePreviewViewController.swift
@@ -60,7 +60,7 @@ class TradeItTradePreviewViewController: TradeItViewController, UITableViewDeleg
             forCellReuseIdentifier: "PREVIEW_MESSAGE_CELL_ID"
         )
 
-        TradeItSDK.adService.populate?(
+        TradeItSDK.adService.populate(
             adContainer: adContainer,
             rootViewController: self,
             pageType: .trading,

--- a/TradeItIosTicketSDK2/TradeItTradingConfirmationViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItTradingConfirmationViewController.swift
@@ -32,7 +32,7 @@ import UIKit
         self.orderNumberLabel.text = "Order #\(self.orderNumber ?? "")"
         self.confirmationTextLabel.text = confirmationMessage
 
-        TradeItSDK.adService.populate?(
+        TradeItSDK.adService.populate(
             adContainer: adContainer,
             rootViewController: self,
             pageType: .confirmation,

--- a/TradeItIosTicketSDK2/TradeItTradingTicketViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItTradingTicketViewController.swift
@@ -59,7 +59,7 @@ class TradeItTradingTicketViewController: TradeItViewController, UITableViewData
 
         self.updateOrderCapabilities()
         
-        TradeItSDK.adService.populate?(
+        TradeItSDK.adService.populate(
             adContainer: adContainer,
             rootViewController: self,
             pageType: .trading,


### PR DESCRIPTION
Not sure why the new version of method with more arguments was made optional, but it means that partners who don't implement it will be missing ads on a lot of screens. Can we remove it? Is there a better way to solve this problem?