### PR TITLE
Make UiConfig (Branding) optional at the SDK level

### DIFF
--- a/ExampleApp/ExampleViewController.swift
+++ b/ExampleApp/ExampleViewController.swift
@@ -13,12 +13,14 @@ class Action {
     init(
         label: String,
         action: @escaping () -> Void,
-        oAuthCallbackUrl: String = "tradeItExampleScheme://completeOAuth"
+        oAuthCallbackUrl: String = "tradeItExampleScheme://completeOAuth",
+        isUiConfigServiceEnabled: Bool = true
     ) {
         self.label = label
         self.action = {
             TradeItSDK.oAuthCallbackUrl = URL(string: oAuthCallbackUrl)!
             action()
+            TradeItSDK.uiConfigService.isEnabled = isUiConfigServiceEnabled
         }
     }
 }
@@ -27,12 +29,14 @@ class YahooAction: Action {
     override init(
         label: String,
         action: @escaping () -> Void,
-        oAuthCallbackUrl: String = "tradeItExampleScheme://completeYahooOAuth"
+        oAuthCallbackUrl: String = "tradeItExampleScheme://completeYahooOAuth",
+        isUiConfigServiceEnabled: Bool = false
     ) {
         super.init(
             label: label,
             action: action,
-            oAuthCallbackUrl: oAuthCallbackUrl
+            oAuthCallbackUrl: oAuthCallbackUrl,
+            isUiConfigServiceEnabled: isUiConfigServiceEnabled
         )
     }
 }

--- a/TradeItIosEmsApi/TradeItUiConfigResult.m
+++ b/TradeItIosEmsApi/TradeItUiConfigResult.m
@@ -2,4 +2,13 @@
 
 @implementation TradeItUiConfigResult
 
+
+-(id)init {
+    if (self = [super init])  {
+        self.brokers = [NSArray<TradeItUiBrokerConfig> new];
+    }
+
+    return self;
+};
+
 @end

--- a/TradeItIosTicketSDK2/TradeItBrokerLogoService.swift
+++ b/TradeItIosTicketSDK2/TradeItBrokerLogoService.swift
@@ -28,7 +28,7 @@ class TradeItBrokerLogoService {
                     return Promise(
                         error: TradeItErrorResult(
                             title: "Logo not found",
-                            message: "No logo is available for this broker."
+                            message: "No logo is enabled for this broker."
                         )
                     )
                 }

--- a/TradeItIosTicketSDK2/TradeItLauncher.swift
+++ b/TradeItIosTicketSDK2/TradeItLauncher.swift
@@ -18,7 +18,9 @@ protocol OAuthCompletionListener {
     static var accountSelectionCallback: ((TradeItLinkedBrokerAccount) -> Void)? // Ew, gross. No other way to do this.
     static var accountSelectionTitle: String? // Ew, gross. No other way to do this.
 
-    override internal init() {}
+    override internal init() {
+        TradeItSDK.uiConfigService.isEnabled = true
+    }
 
     public func handleOAuthCallback(
         onTopmostViewController topMostViewController: UIViewController,

--- a/TradeItIosTicketSDK2/TradeItSelectionDetailCellTableViewCell.swift
+++ b/TradeItIosTicketSDK2/TradeItSelectionDetailCellTableViewCell.swift
@@ -23,7 +23,7 @@ class TradeItSelectionDetailCellTableViewCell: BrandedTableViewCell {
             withSize: .small,
             onSuccess: { image in
                 self.setBrokerNameAsLogoState(logo: image)
-        },
+            },
             onFailure: { }
         )
     }

--- a/TradeItIosTicketSDK2/TradeItSelectionDetailCellTableViewCell.swift
+++ b/TradeItIosTicketSDK2/TradeItSelectionDetailCellTableViewCell.swift
@@ -13,36 +13,31 @@ class TradeItSelectionDetailCellTableViewCell: BrandedTableViewCell {
         detailPrimaryText: String?,
         detailSecondaryText: String?,
         altTitleText: String,
-        linkedBroker: TradeItLinkedBroker? = nil,
-        isBrandingEnabled: Bool = true
+        linkedBroker: TradeItLinkedBroker? = nil
     ) {
         self.detailPrimaryLabel.text = detailPrimaryText
         self.detailSecondaryLabel.text = detailSecondaryText
         setBrokerNameAsTextState(altTitleText: altTitleText)
-        if isBrandingEnabled {
-            TradeItSDK.brokerLogoService.loadLogo(
-                forBrokerId: linkedBroker?.brokerName,
-                withSize: .small,
-                onSuccess: { image in
-                    self.setBrokerNameAsLogoState(logo: image)
-                },
-                onFailure: { }
-            )
-        }
+        TradeItSDK.brokerLogoService.loadLogo(
+            forBrokerId: linkedBroker?.brokerName,
+            withSize: .small,
+            onSuccess: { image in
+                self.setBrokerNameAsLogoState(logo: image)
+        },
+            onFailure: { }
+        )
     }
 
     func configure(
         detailPrimaryText: String?,
         detailSecondaryText: String?,
-        linkedBroker: TradeItLinkedBroker? = nil,
-        isBrandingEnabled: Bool = true
+        linkedBroker: TradeItLinkedBroker? = nil
     ) {
         self.configure(
             detailPrimaryText: detailPrimaryText,
             detailSecondaryText: detailSecondaryText,
             altTitleText: linkedBroker?.brokerLongName ?? "Unknown broker",
-            linkedBroker: linkedBroker,
-            isBrandingEnabled: isBrandingEnabled
+            linkedBroker: linkedBroker
         )
     }
 }

--- a/TradeItIosTicketSDK2/TradeItUiConfigService.swift
+++ b/TradeItIosTicketSDK2/TradeItUiConfigService.swift
@@ -11,9 +11,7 @@ class TradeItUiConfigService: NSObject {
 
     func getUiConfigPromise() -> Promise<TradeItUiConfigResult> {
         if !isEnabled {
-            return Promise { fulfill, reject in
-                fulfill(TradeItUiConfigResult())
-            }
+            return Promise(value: TradeItUiConfigResult())
         }
 
         if let uiConfigPromise = self.uiConfigPromise { return uiConfigPromise }

--- a/TradeItIosTicketSDK2/TradeItUiConfigService.swift
+++ b/TradeItIosTicketSDK2/TradeItUiConfigService.swift
@@ -3,12 +3,19 @@ import PromiseKit
 class TradeItUiConfigService: NSObject {
     private let connector: TradeItConnector
     private var uiConfigPromise: Promise<TradeItUiConfigResult>? = nil
+    var isEnabled = true
 
     init(connector: TradeItConnector) {
         self.connector = connector
     }
 
     func getUiConfigPromise() -> Promise<TradeItUiConfigResult> {
+        if !isEnabled {
+            return Promise { fulfill, reject in
+                fulfill(TradeItUiConfigResult())
+            }
+        }
+
         if let uiConfigPromise = self.uiConfigPromise { return uiConfigPromise }
 
         let uiConfigRequest = TradeItUiConfigRequest(apiKey: connector.apiKey)

--- a/TradeItIosTicketSDK2/TradeItYahooLauncher.swift
+++ b/TradeItIosTicketSDK2/TradeItYahooLauncher.swift
@@ -10,7 +10,9 @@ import SafariServices
     private let linkBrokerUIFlow = TradeItYahooLinkBrokerUIFlow()
     private let alertManager = TradeItAlertManager()
     
-    override internal init() {}
+    override internal init() {
+        TradeItSDK.uiConfigService.isEnabled = false
+    }
     
     public func launchOAuth(fromViewController viewController: UIViewController) {
         self.launchOAuth(

--- a/TradeItIosTicketSDK2/TradeItYahooTradingTicketViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItYahooTradingTicketViewController.swift
@@ -475,8 +475,7 @@ class TradeItYahooTradingTicketViewController: TradeItYahooViewController, UITab
             detailCell.configure(
                 detailPrimaryText: self.order.linkedBrokerAccount?.getFormattedAccountName(),
                 detailSecondaryText: accountSecondaryText(),
-                altTitleText: ticketRow.getTitle(forOrder: self.order),
-                isBrandingEnabled: false
+                altTitleText: ticketRow.getTitle(forOrder: self.order)
             )
         }
 


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/156885801

1. 8f4130e Allows for the configuration of UiConfig to enable/disable branding across all calls to the service by returning an empty array of configs without making a network request. **This solution makes the assumption that no partner integration calls __both__ `YahooLauncher` __and_ `TradeItLauncher`.
   - The changes to `ExampleViewController` should only be necessary in order to change `TradeItSDK.uiConfigService` on the fly after the application has been initialized (as our example app makes use of __both__ `YahooLauncher` and `TradeItLauncher`.
   - If Y! uses `TradeItSDK.tradeItLauncher` this PR may be inadequate. 
1. 13f31ff Removes the branding enable/disable on a per-cell basis. We may want this later but it serves no purpose for the time being. Should we go down this road we should allow for this configuration consistently across all branded cells.