### PR TITLE
Display all Order Sections on Order Screen

### DIFF
--- a/TradeItIosTicketSDK2/TradeItBrandedAccountNameCell.xib
+++ b/TradeItIosTicketSDK2/TradeItBrandedAccountNameCell.xib
@@ -30,6 +30,7 @@
                     </label>
                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xRZ-8i-od2">
                         <rect key="frame" x="16" y="11" width="150" height="28"/>
+                        <accessibility key="accessibilityConfiguration" identifier="UiImage-BrokerLogo"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="150" id="6iH-qE-1XT"/>
                             <constraint firstAttribute="height" constant="28" id="EOb-5Q-FhW"/>
@@ -47,7 +48,6 @@
                     <constraint firstAttribute="topMargin" secondItem="iL0-PU-Cph" secondAttribute="top" id="A2I-u9-Kfj"/>
                     <constraint firstItem="58j-a5-DPU" firstAttribute="leading" secondItem="xRZ-8i-od2" secondAttribute="leading" id="Q4v-lp-y9f"/>
                     <constraint firstItem="58j-a5-DPU" firstAttribute="centerY" secondItem="xRZ-8i-od2" secondAttribute="centerY" id="U2F-nC-s4z"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="xRZ-8i-od2" secondAttribute="bottom" id="WOT-Wh-XwD"/>
                     <constraint firstAttribute="trailingMargin" secondItem="iL0-PU-Cph" secondAttribute="trailing" id="X8r-eE-TLh"/>
                     <constraint firstItem="xRZ-8i-od2" firstAttribute="centerY" secondItem="csI-fC-Lxk" secondAttribute="centerY" id="auK-OS-aIF"/>
                     <constraint firstItem="iL0-PU-Cph" firstAttribute="leading" secondItem="58j-a5-DPU" secondAttribute="trailing" constant="10" id="f5Z-d1-ZQP"/>

--- a/TradeItIosTicketSDK2/TradeItOrdersTableViewManager.swift
+++ b/TradeItIosTicketSDK2/TradeItOrdersTableViewManager.swift
@@ -47,7 +47,7 @@ class TradeItOrdersTableViewManager: NSObject, UITableViewDelegate, UITableViewD
         self.orderSectionPresenters = []
         
         let openOrders = orders.filter { $0.belongsToOpenCategory()}
-        if openOrders.count > 0 {
+        if !openOrders.isEmpty {
             let openOrdersPresenter = getOrdersPresenter(orders: openOrders)
             self.orderSectionPresenters.append(
                 OrderSectionPresenter(
@@ -60,7 +60,7 @@ class TradeItOrdersTableViewManager: NSObject, UITableViewDelegate, UITableViewD
         }
         
         let partiallyFilledOrders = orders.filter { $0.belongsToPartiallyFilledCategory() }
-        if partiallyFilledOrders.count > 0 {
+        if !partiallyFilledOrders.isEmpty {
             let partiallyFilledOrdersPresenter = getOrdersPresenter(orders: partiallyFilledOrders)
             self.orderSectionPresenters.append(
                 OrderSectionPresenter(
@@ -73,7 +73,7 @@ class TradeItOrdersTableViewManager: NSObject, UITableViewDelegate, UITableViewD
         }
         
         let filledOrders = orders.filter { $0.belongsToFilledCategory() }
-        if filledOrders.count > 0 {
+        if !filledOrders.isEmpty {
             let filledOrdersPresenter = getOrdersPresenter(orders: filledOrders)
             self.orderSectionPresenters.append(
                 OrderSectionPresenter(
@@ -85,7 +85,7 @@ class TradeItOrdersTableViewManager: NSObject, UITableViewDelegate, UITableViewD
         }
 
         let otherOrders = orders.filter { $0.belongsToOtherCategory() }
-        if otherOrders.count > 0 {
+        if !otherOrders.isEmpty {
             let otherOrdersPresenter = getOrdersPresenter(orders: otherOrders)
             self.orderSectionPresenters.append(
                 OrderSectionPresenter(
@@ -194,13 +194,13 @@ class TradeItOrdersTableViewManager: NSObject, UITableViewDelegate, UITableViewD
 
     // MARK: Private
     fileprivate enum Section: Int {
-        case accountInfo = 0, firstOrderSection
+        case accountInfo = 0, firstOrderCategory
     }
 
     private func getOrderSectionPresenter(forSection section: Int) -> OrderSectionPresenter? {
-        let zeroIndexedPresenter = section - Section.firstOrderSection.rawValue
+        let indexOfOrderCategory = section - Section.firstOrderCategory.rawValue
 
-        return orderSectionPresenters[safe: zeroIndexedPresenter]
+        return orderSectionPresenters[safe: indexOfOrderCategory]
     }
     
     private func addRefreshControl(toTableView tableView: UITableView) {

--- a/TradeItIosTicketSDK2/TradeItPortfolioAccountDetailsViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItPortfolioAccountDetailsViewController.swift
@@ -22,7 +22,6 @@ class TradeItPortfolioAccountDetailsViewController: TradeItViewController, Trade
         }
 
         self.tableViewManager = TradeItPortfolioAccountDetailsTableViewManager(account: linkedBrokerAccount)
-        self.navigationItem.title = linkedBrokerAccount.linkedBroker?.brokerLongName
 
         self.tableViewManager.delegate = self
         self.tableViewManager.table = self.table


### PR DESCRIPTION
Story (see story discussion): https://www.pivotaltracker.com/story/show/156672415

This PR tackles 3 issues:
1- Retitle the navbar in the Portfolio Overview screen to `Portfolio`. This is consistent with our other screens.
1- Fix constraint violations introduced by https://github.com/tradingticket/TradeItIosTicketSDK2/commit/8aa7f5539934341fbd1e7f0dd6f9d3bd6f2c3fb6#diff-643958e9e7ea57dbc4df2566e814e53b
1- https://github.com/tradingticket/TradeItIosTicketSDK2/commit/8aa7f5539934341fbd1e7f0dd6f9d3bd6f2c3fb6#diff-643958e9e7ea57dbc4df2566e814e53b introduced a bug wherein the branded `Account Info` section was overwriting the next (preexisting) section within the `ordersTable`.

Pre-fix screenshot (notice absence of `Open orders`):
![screen shot 2018-05-03 at 5 56 30 pm](https://user-images.githubusercontent.com/10605247/39604731-5d23a4c4-4efb-11e8-85d3-1fd0ac47dcf8.png)

Post-fix screenshot:
![screen shot 2018-05-03 at 5 54 52 pm](https://user-images.githubusercontent.com/10605247/39604694-4395f430-4efb-11e8-9e45-400a2c568195.png)
