### PR TITLE
Static lib

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "Boris-Em/BEMCheckBox" "1.4.1"
-github "JSONModel/JSONModel" "1.7.0"
-github "jdg/MBProgressHUD" "1.1.0"
-github "mxcl/PromiseKit" "6.2.8"
+github "Boris-Em/BEMCheckBox" ~> 1.4.1
+github "JSONModel/JSONModel" ~> 1.7.0
+github "jdg/MBProgressHUD" ~> 1.0.0
+github "mxcl/PromiseKit" ~> 6.2.8

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "mxcl/PromiseKit" ~> 4.4
-github "jdg/MBProgressHUD" ~> 1.0.0
-github "JSONModel/JSONModel" "master"
-github "Boris-Em/BEMCheckBox" ~> 1.4.1
+github "Boris-Em/BEMCheckBox" "1.4.1"
+github "JSONModel/JSONModel" "1.7.0"
+github "jdg/MBProgressHUD" "1.1.0"
+github "mxcl/PromiseKit" "6.2.8"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Boris-Em/BEMCheckBox" "1.4.1"
-github "JSONModel/JSONModel" "cebb6d9cc1320eb20b61adea31a0c894b3cb7266"
+github "JSONModel/JSONModel" "1.7.0"
 github "jdg/MBProgressHUD" "1.1.0"
-github "mxcl/PromiseKit" "4.5.2"
+github "mxcl/PromiseKit" "6.2.8"

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ def testing_pods
 end
 
 def app_pods
-  pod 'PromiseKit', '~> 6.0'
+  pod 'PromiseKit', '~> 6.2.8'
   pod 'MBProgressHUD', '~> 1.1.0'
   pod 'JSONModel', '~> 1.7.0'
   pod 'BEMCheckBox', '~> 1.4.1'

--- a/TradeItIosEmsApi/TradeItConnector.m
+++ b/TradeItIosEmsApi/TradeItConnector.m
@@ -12,7 +12,11 @@
 #ifdef CARTHAGE
 #import <TradeItIosTicketSDK2Carthage/TradeItIosTicketSDK2Carthage-Swift.h>
 #else
-#import <TradeItIosTicketSDK2/TradeItIosTicketSDK2-Swift.h>
+    #if __has_include("TradeItIosTicketSDK2-Swift.h")
+        #import "TradeItIosTicketSDK2-Swift.h"
+    #else
+        #import <TradeItIosTicketSDK2/TradeItIosTicketSDK2-Swift.h>
+    #endif
 #endif
 
 @interface TradeItConnector()

--- a/TradeItIosEmsApi/TradeItCryptoPreviewTradeRequest.h
+++ b/TradeItIosEmsApi/TradeItCryptoPreviewTradeRequest.h
@@ -1,4 +1,4 @@
-#import <TradeItIosTicketSDK2/TradeItIosTicketSDK2.h>
+#import "TradeItAuthenticatedRequest.h"
 
 @interface TradeItCryptoPreviewTradeRequest : TradeItAuthenticatedRequest
 

--- a/TradeItIosEmsApi/TradeItUserAgentProvider.m
+++ b/TradeItIosEmsApi/TradeItUserAgentProvider.m
@@ -5,7 +5,11 @@
 #ifdef CARTHAGE
     #import <TradeItIosTicketSDK2Carthage/TradeItIosTicketSDK2Carthage-Swift.h>
 #else
-    #import <TradeItIosTicketSDK2/TradeItIosTicketSDK2-Swift.h>
+    #if __has_include("TradeItIosTicketSDK2-Swift.h")
+        #import "TradeItIosTicketSDK2-Swift.h"
+    #else
+        #import <TradeItIosTicketSDK2/TradeItIosTicketSDK2-Swift.h>
+    #endif
 #endif
 
 @implementation TradeItUserAgentProvider

--- a/TradeItIosTicketSDK2.podspec
+++ b/TradeItIosTicketSDK2.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   }
 
   s.frameworks = 'UIKit'
-  s.dependency 'PromiseKit', '~> 6.0'
+  s.dependency 'PromiseKit', '~> 6.2.8'
   s.dependency 'MBProgressHUD', '~> 1.0.0'
   s.dependency 'JSONModel', '~> 1.7.0'
   s.dependency 'BEMCheckBox', '~> 1.4.1'


### PR DESCRIPTION
To build a static lib the developer has to specify `use_modular_headers!` in their pod file. If our SDK is used in Objective-C code the user need to replace `#import <TradeItIosTicketSDK2/TradeItIosTicketSDK2-Swift.h>` with `@import TradeItIosTicketSDK2.Swift;`. 

You could test this branch by adding the following to `Podfile`: `pod 'TradeItIosTicketSDK2', :git => 'https://github.com/tradingticket/TradeItIosTicketSDK2.git', :branch => 'static-lib'`


**Note:** `@import TradeItIosTicketSDK2.Swift;` also works if the developer has `use_frameworks!` in their pod file.