### PR TITLE
Add LinkedBrokers with a session error to the DisplayableLinkedBrokers

### DIFF
--- a/TradeItIosTicketSDK2/TradeItLinkedBrokerManager.swift
+++ b/TradeItIosTicketSDK2/TradeItLinkedBrokerManager.swift
@@ -225,7 +225,7 @@ import PromiseKit
     }
     
     @objc public func getAllDisplayableLinkedBrokers() -> [TradeItLinkedBroker] {
-        return self.linkedBrokers.filter { $0.getEnabledAccounts().count > 0 || $0.isAccountLinkDelayedError}
+        return self.linkedBrokers.filter { $0.getEnabledAccounts().count > 0 || $0.error?.requiresAuthentication() == true }
     }
     
     @objc public func getAllActivationInProgressLinkedBrokers() -> [TradeItLinkedBroker] {


### PR DESCRIPTION
`authenticateAll` was using `getAllDisplayableLinkedBrokers` which was filtering out any linked broker without any accounts. This is a problem because when a broker is just linked and not yet authenticated there are 0 accounts. `authenticateAll` was then never authenticating it. I checked the other usages of `getAllDisplayableLinkedBrokers` and this seems to be a safe change.