### PR TITLE
Light mode code modification for yahoo finance iOS app

### DIFF
--- a/TradeItIosTicketSDK2/TradeItYahooEquityTradingTicketViewController.swift
+++ b/TradeItIosTicketSDK2/TradeItYahooEquityTradingTicketViewController.swift
@@ -80,6 +80,10 @@ class TradeItYahooEquityTradingTicketViewController: TradeItYahooViewController,
         }
     }
 
+    override func closeButtonTitle() -> String {
+        return "Cancel"
+    }
+
     // MARK: UITableViewDelegate
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/TradeItIosTicketSDK2/TradeItYahooNavigationController.swift
+++ b/TradeItIosTicketSDK2/TradeItYahooNavigationController.swift
@@ -13,28 +13,11 @@ class TradeItYahooNavigationController: UINavigationController {
     }
 
     private func setupFuji() {
-        self.navigationBar.barStyle = .black
-        self.navigationBar.tintColor = .white
-        let blankImage = UIImage()
-        self.navigationBar.setBackgroundImage(blankImage, for: .default)
-        self.navigationBar.shadowImage = blankImage
+        self.navigationBar.isTranslucent = false
+        self.navigationBar.barTintColor = .white
+        self.navigationBar.tintColor = UIColor(red: 24/255, green: 143/255, blue: 1, alpha: 1)
 
-        let gradientView = TopGradientView(frame: self.view.frame)
-        addNavigationGradientView(gradientView)
-
-        let colorGradientView = LinearGradientView()
-        addNavigationGradientView(colorGradientView)
-    }
-    
-    private func addNavigationGradientView(_ subview: UIView) {
-        subview.translatesAutoresizingMaskIntoConstraints = false
-        self.view.addSubview(subview)
-        self.view.sendSubviewToBack(subview)
-        self.view.addConstraints([
-            subview.topAnchor.constraint(equalTo: self.view.topAnchor),
-            subview.widthAnchor.constraint(equalTo: self.view.widthAnchor),
-            subview.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            subview.heightAnchor.constraint(equalToConstant: self.navigationBarHeight)
-        ])
+        let textAttributes = [NSAttributedStringKey.foregroundColor:UIColor.black]
+        self.navigationBar.titleTextAttributes = textAttributes
     }
 }

--- a/TradeItIosTicketSDK2/TradeItYahooNavigationController.swift
+++ b/TradeItIosTicketSDK2/TradeItYahooNavigationController.swift
@@ -20,4 +20,8 @@ class TradeItYahooNavigationController: UINavigationController {
         let textAttributes = [NSAttributedStringKey.foregroundColor:UIColor.black]
         self.navigationBar.titleTextAttributes = textAttributes
     }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return UIStatusBarStyle.default
+    }
 }


### PR DESCRIPTION
Hello Tradeit team,

I am from YahooFinance iOS team and working on the screen `TradeItYahooEquityTradingTicketViewController` lightMode design which requires the header to be white, and the leftBarItem to be `Cancel`. Screenshot attached. 

Feel free to reach out to me `@gzhu` on slack `#finance-tradeit-dev` channel.

_**Current Design**_
<img src="https://user-images.githubusercontent.com/12547633/59701836-725fa880-91c4-11e9-922a-5c85d025b042.png" width=300 />


**_Previous design_**

<img src="https://user-images.githubusercontent.com/12547633/59696866-d67d6f00-91ba-11e9-81be-4c8917c6c8fb.png" width=250 />

